### PR TITLE
Made timeouts be processed on a path level

### DIFF
--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -24,6 +24,8 @@ public class Discombobulator implements Plugin<Project> {
 	public static PreprocessingConfiguration config;
 
 	public static Processor processor;
+	
+	public static PathLock pathLock;
 
 	/**
 	 * Apply the gradle plugin to the project
@@ -34,6 +36,8 @@ public class Discombobulator implements Plugin<Project> {
 		config = project.getExtensions().create("discombobulator", PreprocessingConfiguration.class);
 		// Create Processor
 		processor = new Processor();
+		// Create schedule
+		pathLock = new PathLock();
 		// Register tasks
 		TaskPreprocessBase baseTask = project.getTasks().register("preprocessBase", TaskPreprocessBase.class).get();
 		baseTask.setGroup("dicombobulator");

--- a/src/main/java/com/minecrafttas/discombobulator/PathLock.java
+++ b/src/main/java/com/minecrafttas/discombobulator/PathLock.java
@@ -1,0 +1,49 @@
+package com.minecrafttas.discombobulator;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Locks certain paths from being preprocessed during a modify file event.<br>
+ * The lock lasts for 1000 ms and each path has it's own timer.
+ * 
+ * @author Scribble
+ *
+ */
+public class PathLock {
+	
+	/**
+	 * A list of locks
+	 */
+	private Map<Path, Long> locks = Collections.synchronizedMap(new HashMap<>());
+	
+	/**
+	 * Locks the path and captures the current time
+	 * @param path The path to lock
+	 */
+	public void scheduleAndLock(Path path) {
+		locks.put(path, System.currentTimeMillis());
+	}
+	
+	/**
+	 * Checks if the path is locked and should be skipped
+	 * @param path The path to check for
+	 * @return If the path is locked
+	 */
+	public boolean isLocked(Path path) {
+		if(locks.containsKey(path)) {
+			long startTime = locks.get(path);
+			if(System.currentTimeMillis()-startTime > 1000) {
+				locks.remove(path);
+				return false;
+			} else {
+				return true;
+			}
+			
+		}
+		return false;
+	}
+	
+}


### PR DESCRIPTION
## Old
The timeouts would happen on a version level. The whole version would be locked for 1000ms and would not accept any changes, making changes in multiple files be lost
## New
Timeouts are processed on a path level. If a file is modified, all paths in other versions are locked for 1000ms. That way if the file is modified in the other version, the file watcher in that version will skip the locked path.  
This supports changes in multiple files at once, for example during refactoring
