### PR TITLE
Add task preprocessVersion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 22 for x64
+    - name: Set up JDK 23 for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '22'
+        java-version: '23'
         distribution: 'temurin'
         architecture: x64
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
       with:
-        gradle-version: 8.10.2
+        gradle-version: 8.12.1
     - name: Build
       run: gradle build
     - name: Upload Test Report

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -10,5 +10,5 @@ discombobulator {
 	
 	ignoredFileFormats = ["*.png"]
 	
-	disableAnsi = true
+	disableAnsi = false
 }

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -9,4 +9,6 @@ discombobulator {
 	]
 	
 	ignoredFileFormats = ["*.png"]
+	
+	disableAnsi = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 	id 'maven-publish'
 }
 
-// Change java compatibility level to 22
-sourceCompatibility = targetCompatibility = 22
+// Change java compatibility level to 23
+sourceCompatibility = targetCompatibility = 23
 
 // Name, version and group for the project
 version = "1.3-SNAPSHOT"

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -48,6 +48,8 @@ public class Discombobulator implements Plugin<Project> {
 
 	public static PreprocessingConfiguration config;
 
+	public static boolean DISABLE_ANSI = false;
+
 	public static FilePreprocessor fileProcessor;
 
 	public static PathLock pathLock;
@@ -95,6 +97,7 @@ public class Discombobulator implements Plugin<Project> {
 		project.afterEvaluate(_project -> {
 			boolean inverted = config.getInverted().getOrElse(false);
 			PORT_LOCK = config.getPort().getOrElse(8762);
+			DISABLE_ANSI = config.getDisableAnsi().getOrElse(false);
 
 			Map<String, Path> versionPairs = null;
 			Path projectDir = _project.getProjectDir().toPath();

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -32,6 +32,7 @@ import com.minecrafttas.discombobulator.processor.LinePreprocessor;
 import com.minecrafttas.discombobulator.tasks.TaskCollectBuilds;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessBase;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessVersion;
+import com.minecrafttas.discombobulator.tasks.TaskPreprocessVersionError;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch;
 import com.minecrafttas.discombobulator.utils.Colors;
 import com.minecrafttas.discombobulator.utils.PathLock;
@@ -79,12 +80,17 @@ public class Discombobulator implements Plugin<Project> {
 		List<Task> compileTasks = new ArrayList<>();
 		for (Project subProject : project.getSubprojects()) {
 			compileTasks.add(subProject.getTasksByName("remapJar", false).iterator().next());
-
+			// Register preprocessVersion task in subProjects
 			TaskPreprocessVersion versionTask = subProject.getTasks().register("preprocessVersion", TaskPreprocessVersion.class).get();
 			versionTask.setGroup("discombobulator");
 			versionTask.setDescription("Preprocesses this version back to the base folder and to versions other than this one");
 		}
 		collectBuilds.updateCompileTasks(compileTasks);
+
+		// Register preprocessVersion task in root
+		TaskPreprocessVersionError versionTaskRoot = project.getTasks().register("preprocessVersion", TaskPreprocessVersionError.class).get();
+		versionTaskRoot.setGroup("discombobulator");
+		versionTaskRoot.setDescription("Do not use this task! Use it in subprojects!");
 
 		project.afterEvaluate(_project -> {
 			boolean inverted = config.getInverted().getOrElse(false);

--- a/src/main/java/com/minecrafttas/discombobulator/extensions/PreprocessingConfiguration.java
+++ b/src/main/java/com/minecrafttas/discombobulator/extensions/PreprocessingConfiguration.java
@@ -49,6 +49,12 @@ public abstract class PreprocessingConfiguration {
 	public abstract Property<Boolean> getInverted();
 
 	/**
+	 * If true, disables ANSI colors
+	 * @return
+	 */
+	public abstract Property<Boolean> getDisableAnsi();
+
+	/**
 	 * The port for the port lock
 	 * @return The port number
 	 */

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -18,10 +18,10 @@ import java.util.Map.Entry;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 import com.minecrafttas.discombobulator.Discombobulator;
+import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch.CurrentFilePreprocessAction;
 import com.minecrafttas.discombobulator.utils.BetterFileWalker;
 import com.minecrafttas.discombobulator.utils.LineFeedHelper;
 import com.minecrafttas.discombobulator.utils.SafeFileOperations;
-import com.minecrafttas.discombobulator.utils.Triple;
 
 public class FilePreprocessor {
 
@@ -33,6 +33,15 @@ public class FilePreprocessor {
 		this.fileFilter = fileFilter;
 	}
 
+	/**
+	 * Preprocesses a single file into the target version
+	 * 
+	 * @param inFile The path to the file that will be preprocessed  
+	 * @param outFile The path to the file where the preprocessed file will be stored stored
+	 * @param version The target version to preprocess to            
+	 * @param extension The file extension (e.g. ".java") of the file
+	 * @throws Exception If the preprocessing fails
+	 */
 	public void preprocessFile(Path inFile, Path outFile, String version, String extension) throws Exception {
 
 //		System.out.println(inFile);
@@ -69,9 +78,21 @@ public class FilePreprocessor {
 		preprocessLines(linesToProcess, outFile, version, extension);
 	}
 
-	public Triple<List<String>, Path, Path> /*<- TODO Change to it's own class*/ preprocessVersions(Path inFile, Map<String, Path> versions, String extension, Path currentDir, boolean verbose) throws Exception {
+	/**
+	 * Preprocess a file into multiple target versions
+	 * 
+	 * @param inFile The file to preprocess
+	 * @param versions The mapped versions to preprocess to.
+	 * @param extension The file extension (e.g. ".java") of the file
+	 * @param currentVersionDir The current version directory that where the file that is being worked on lies.<br>
+	 * Used for checking if you are trying to preprocess into the current directory, which can lead to issues otherwise.
+	 * @param verbose If more info should be printed to the console
+	 * @return The {@link CurrentFilePreprocessAction}
+	 * @throws Exception If the preprocessing fails
+	 */
+	public CurrentFilePreprocessAction preprocessVersions(Path inFile, Map<String, Path> versions, String extension, Path currentVersionDir, boolean verbose) throws Exception {
 
-		Path relativeInFile = currentDir.relativize(inFile);
+		Path relativeInFile = currentVersionDir.relativize(inFile);
 		System.out.println(String.format("Preprocessing %s%s%s%s%s", relativeInFile.getParent(), File.separator, PURPLE, relativeInFile.getFileName().toString(), WHITE));
 
 		boolean ignored = fileFilter != null && fileFilter.accept(inFile.toFile());
@@ -82,7 +103,7 @@ public class FilePreprocessor {
 		else
 			System.out.println(String.format("Ignoring %s%s%s", YELLOW, inFile.getFileName().toString(), WHITE));
 
-		Triple<List<String>, Path, Path> out = null;
+		CurrentFilePreprocessAction out = null;
 
 		// Iterate through all versions
 		for (Entry<String, Path> versionPair : versions.entrySet()) {
@@ -91,6 +112,7 @@ public class FilePreprocessor {
 			Path targetSubSourceDir = targetProject.resolve("src");
 			Path outFile = targetSubSourceDir.resolve(relativeInFile);
 
+			// Stop certain file types to be preprocessed (e.g. ".png")
 			if (ignored) {
 				if (verbose) {
 					System.out.println(String.format("into version %s%s%s", CYAN, versionName, WHITE));
@@ -103,8 +125,8 @@ public class FilePreprocessor {
 			List<String> outLines = processor.preprocess(versionName, linesToProcess, extension);
 
 			// If the version equals the original version, then skip it
-			if (targetSubSourceDir.equals(currentDir)) {
-				out = Triple.of(outLines, inFile, outFile);
+			if (targetSubSourceDir.equals(currentVersionDir)) {
+				out = new CurrentFilePreprocessAction(outLines, inFile, outFile);
 				continue;
 			}
 
@@ -127,7 +149,20 @@ public class FilePreprocessor {
 	 */
 	public List<String> preprocessLines(List<String> inLines, Path outFile, String version, String extension) throws Exception {
 		List<String> lines = processor.preprocess(version, inLines, extension);
+		writeLines(inLines, outFile);
+		return lines;
+	}
 
+	///
+	/// 1. Locks the file to stop the filewatcher from detecting it
+	/// 2. Creates any missing directories
+	/// 3. Writes the lines with the line feed specified by the `line.seperator` system property
+	///
+	/// @param inLines
+	/// @param outFile
+	/// @throws Exception
+	///
+	private void writeLines(List<String> inLines, Path outFile) throws Exception {
 		// Lock the file
 		Discombobulator.pathLock.scheduleAndLock(outFile);
 
@@ -136,13 +171,11 @@ public class FilePreprocessor {
 
 		StringBuilder stringBuilder = new StringBuilder();
 		String linefeed = LineFeedHelper.newLine();
-		for (String line : lines) {
+		for (String line : inLines) {
 			stringBuilder.append(line);
 			stringBuilder.append(linefeed);
 		}
 		Files.write(outFile, stringBuilder.toString().getBytes());
-
-		return lines;
 	}
 
 	/**
@@ -183,4 +216,5 @@ public class FilePreprocessor {
 	public WildcardFileFilter getFileFilter() {
 		return fileFilter;
 	}
+
 }

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -38,7 +38,7 @@ public class FilePreprocessor {
 	 * 
 	 * @param inFile The path to the file that will be preprocessed  
 	 * @param outFile The path to the file where the preprocessed file will be stored stored
-	 * @param version The target version to preprocess to            
+	 * @param version The target version to preprocess to. null if the target is the base source
 	 * @param extension The file extension (e.g. ".java") of the file
 	 * @throws Exception If the preprocessing fails
 	 */
@@ -66,6 +66,13 @@ public class FilePreprocessor {
 		if (Discombobulator.pathLock.isLocked(inFile)) {
 			return;
 		}
+
+		String targetVersion = version;
+		if (targetVersion == null) {
+			targetVersion = "Base";
+		}
+
+		System.out.println(String.format("into version %s%s%s", CYAN, targetVersion, WHITE));
 
 		if (fileFilter != null && fileFilter.accept(inFile.toFile())) {
 			System.out.println(String.format("Ignoring %s%s%s", YELLOW, inFile.getFileName().toString(), WHITE));
@@ -100,8 +107,6 @@ public class FilePreprocessor {
 		List<String> linesToProcess = null;
 		if (!ignored)
 			linesToProcess = Files.readAllLines(inFile);
-		else
-			System.out.println(String.format("Ignoring %s%s%s", YELLOW, inFile.getFileName().toString(), WHITE));
 
 		CurrentFilePreprocessAction out = null;
 
@@ -114,9 +119,13 @@ public class FilePreprocessor {
 
 			// Stop certain file types to be preprocessed (e.g. ".png")
 			if (ignored) {
+				if (targetSubSourceDir.equals(currentVersionDir)) {
+					continue;
+				}
 				if (verbose) {
 					System.out.println(String.format("into version %s%s%s", CYAN, versionName, WHITE));
 				}
+				System.out.println(String.format("Ignoring %s%s%s", YELLOW, inFile.getFileName().toString(), WHITE));
 				Files.copy(inFile, outFile, StandardCopyOption.REPLACE_EXISTING);
 				continue;
 			}
@@ -149,7 +158,7 @@ public class FilePreprocessor {
 	 */
 	public List<String> preprocessLines(List<String> inLines, Path outFile, String version, String extension) throws Exception {
 		List<String> lines = processor.preprocess(version, inLines, extension);
-		writeLines(inLines, outFile);
+		writeLines(lines, outFile);
 		return lines;
 	}
 
@@ -165,7 +174,6 @@ public class FilePreprocessor {
 	private void writeLines(List<String> inLines, Path outFile) throws Exception {
 		// Lock the file
 		Discombobulator.pathLock.scheduleAndLock(outFile);
-
 		// Write file and update last modified date
 		Files.createDirectories(outFile.getParent());
 

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -3,6 +3,11 @@ package com.minecrafttas.discombobulator.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
+/**
+ * Task for preprocessing one version into all other versions including the base source
+ * 
+ * @author Scribble
+ */
 public class TaskPreprocessVersion extends DefaultTask {
 
 	@TaskAction

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -7,5 +7,6 @@ public class TaskPreprocessVersion extends DefaultTask {
 
 	@TaskAction
 	public void preprocessVersion() {
+		System.out.println("Test");
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -75,11 +75,11 @@ public class TaskPreprocessVersion extends DefaultTask {
 
 			try {
 				// Preprocess version dir
-				Discombobulator.fileProcessor.preprocessVersions(inFile, versionsConfig, extension, versionSourceDir, false);
+				Discombobulator.fileProcessor.preprocessVersions(inFile, versionsConfig, extension, versionSourceDir, true);
 
 				// Preprocess in base dir
 				Path outFile = baseSourceDir.resolve(path);
-				Discombobulator.fileProcessor.preprocessFile(path, outFile, null, extension);
+				Discombobulator.fileProcessor.preprocessFile(inFile, outFile, null, extension);
 			} catch (MalformedInputException e) {
 				Discombobulator.printError(String.format("Can't process file, probably not a text file...\n Maybe add ignoredFileFormats = [\"*.%s\"] to the build.gradle?", extension), path.getFileName().toString());
 				e.printStackTrace();

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -1,7 +1,20 @@
 package com.minecrafttas.discombobulator.tasks;
 
+import java.nio.charset.MalformedInputException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
+
+import com.minecrafttas.discombobulator.Discombobulator;
+import com.minecrafttas.discombobulator.utils.BetterFileWalker;
+import com.minecrafttas.discombobulator.utils.LineFeedHelper;
+import com.minecrafttas.discombobulator.utils.Pair;
+import com.minecrafttas.discombobulator.utils.SocketLock;
 
 /**
  * Task for preprocessing one version into all other versions including the base source
@@ -11,7 +24,71 @@ import org.gradle.api.tasks.TaskAction;
 public class TaskPreprocessVersion extends DefaultTask {
 
 	@TaskAction
-	public void preprocessVersion() {
-		System.out.println("Test");
+	public void preprocessVersion() throws Exception {
+		System.out.println(Discombobulator.getSplash());
+
+		// Lock port
+		SocketLock lock = new SocketLock(Discombobulator.PORT_LOCK);
+		lock.tryLock();
+
+		// Prepare list of physical version folders
+		Path baseProjectDir = this.getProject().getParent().getProjectDir().toPath();
+		Path baseSourceDir = baseProjectDir.resolve("src");
+
+		Map<String, Path> versionsConfig;
+		try {
+			versionsConfig = Discombobulator.getVersionPairs(baseProjectDir);
+		} catch (Exception e) {
+			if (e.getMessage() != null && !e.getMessage().isEmpty()) {
+				Discombobulator.printError(e.getMessage());
+			} else {
+				e.printStackTrace();
+			}
+			return;
+		}
+
+		Path versionProjectDir = this.getProject().getProjectDir().toPath();
+		Pair<String, Path> masterVersion = null;
+		// Find current version in version config
+
+		for (Entry<String, Path> entry : versionsConfig.entrySet()) {
+			if (entry.getValue().equals(versionProjectDir)) {
+				masterVersion = Pair.of(entry.getKey(), entry.getValue());
+			}
+		}
+
+		if (masterVersion == null) {
+			throw new Exception("Version could not be found in build.gradle");
+		}
+
+		LineFeedHelper.printMessage();
+
+		System.out.println(String.format("Preprocessing version %s...", masterVersion.left()));
+
+		Path versionSourceDir = versionProjectDir.resolve("src");
+		if (!Files.exists(versionSourceDir))
+			throw new RuntimeException("Base source folder not found");
+
+		BetterFileWalker.walk(versionSourceDir, path -> {
+			Path inFile = versionSourceDir.resolve(path);
+			String extension = FilenameUtils.getExtension(path.getFileName().toString());
+
+			try {
+				// Preprocess version dir
+				Discombobulator.fileProcessor.preprocessVersions(inFile, versionsConfig, extension, versionSourceDir, false);
+
+				// Preprocess in base dir
+				Path outFile = baseSourceDir.resolve(path);
+				Discombobulator.fileProcessor.preprocessFile(path, outFile, null, extension);
+			} catch (MalformedInputException e) {
+				Discombobulator.printError(String.format("Can't process file, probably not a text file...\n Maybe add ignoredFileFormats = [\"*.%s\"] to the build.gradle?", extension), path.getFileName().toString());
+				e.printStackTrace();
+				return;
+			} catch (Exception e) {
+				Discombobulator.printError(e.getMessage(), path.getFileName().toString());
+				e.printStackTrace();
+				return;
+			}
+		});
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -11,6 +11,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.minecrafttas.discombobulator.Discombobulator;
+import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch.CurrentFilePreprocessAction;
 import com.minecrafttas.discombobulator.utils.BetterFileWalker;
 import com.minecrafttas.discombobulator.utils.LineFeedHelper;
 import com.minecrafttas.discombobulator.utils.Pair;
@@ -75,7 +76,8 @@ public class TaskPreprocessVersion extends DefaultTask {
 
 			try {
 				// Preprocess version dir
-				Discombobulator.fileProcessor.preprocessVersions(inFile, versionsConfig, extension, versionSourceDir, true);
+				CurrentFilePreprocessAction action = Discombobulator.fileProcessor.preprocessVersions(inFile, versionsConfig, extension, versionSourceDir, true);
+				TaskPreprocessWatch.runFileAction(action);
 
 				// Preprocess in base dir
 				Path outFile = baseSourceDir.resolve(path);

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersionError.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersionError.java
@@ -1,0 +1,23 @@
+package com.minecrafttas.discombobulator.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * <p>Task class for stopping a task.
+ * <p>{@link TaskPreprocessVersion} is intended for <strong>subprojects only!</strong><br>
+ * And since gradle is such a cool program, it automatically creates a task in the root project as well,<br>
+ * that you can not disable apparently.
+ * <p>But you can register separate tasks to the root project, that will execute before everything else, so to stop it,<br>
+ * we just need to throw an exception and it will stop all following tasks. Thanks Gradle! 
+ */
+public class TaskPreprocessVersionError extends DefaultTask {
+
+	@TaskAction
+	public void preprocessVersion() throws Exception {
+		throw new Exception("\n\n!!!!!!!!!! Do not use this task on the root project !!!!!!!!!!\n\n"
+				+ "This task is intended for subprojects only,\n"
+				+ "so this exception will stop it from running on all subprojects.\n"
+				+ "This was the only way I could find to disable the task for the root project, thanks Gradle!\n");
+	}
+}

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -28,7 +28,6 @@ import com.minecrafttas.discombobulator.utils.LineFeedHelper;
 import com.minecrafttas.discombobulator.utils.PathLock;
 import com.minecrafttas.discombobulator.utils.SafeFileOperations;
 import com.minecrafttas.discombobulator.utils.SocketLock;
-import com.minecrafttas.discombobulator.utils.Triple;
 
 /**
  * This task preprocesses the source code on file change
@@ -39,7 +38,7 @@ public class TaskPreprocessWatch extends DefaultTask {
 
 	private List<FileWatcherThread> threads = new ArrayList<>();
 
-	private Triple<List<String>, Path, Path> currentFileUpdater = null;
+	private CurrentFilePreprocessAction currentFileAction = null;
 	/**
 	 * <p>The source dir in the base project that is used for version control<br>
 	 * <code>rootdir/src</code>
@@ -86,17 +85,17 @@ public class TaskPreprocessWatch extends DefaultTask {
 		try {
 			while (!(in = sc.nextLine()).isBlank()) {
 				if (!in.isBlank()) {
-					if (currentFileUpdater == null) {
+					if (currentFileAction == null) {
 						System.out.println("No recent file exists...\n");
 						continue;
 					}
-					Path outFile = currentFileUpdater.right();
-					List<String> outLines = currentFileUpdater.left();
+					Path outFile = currentFileAction.outFile();
+					List<String> outLines = currentFileAction.outLines();
 
 					Discombobulator.pathLock.scheduleAndLock(outFile);
 					Files.createDirectories(outFile.getParent());
 					SafeFileOperations.write(outFile, outLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-					currentFileUpdater = null;
+					currentFileAction = null;
 
 					System.out.println(String.format("Preprocessed the recently edited file %s%s%s\n", PURPLE, outFile.getFileName(), WHITE));
 				}
@@ -147,7 +146,7 @@ public class TaskPreprocessWatch extends DefaultTask {
 				try {
 
 					// Preprocess in all sub versions
-					currentFileUpdater = Discombobulator.fileProcessor.preprocessVersions(path, versions, extension, subSourceDir, true);
+					currentFileAction = Discombobulator.fileProcessor.preprocessVersions(path, versions, extension, subSourceDir, true);
 
 					// Preprocess in base dir
 					Path outFile = baseSourceDir.resolve(relativeInFile);
@@ -226,5 +225,19 @@ public class TaskPreprocessWatch extends DefaultTask {
 			if (watcher != null)
 				watcher.close();
 		}
+	}
+
+	/// 
+	/// Stores data used for preprocessing the file that was edited most recently.
+	///
+	/// This fixes an issue where the IDE will behave weirdly, when trying to preprocess and replace a file,  
+	/// that is currently being worked on. So when saving a file,  
+	/// The file watcher would also replace the file that you just saved, leading to discrepancies and annoyances.
+	///
+	/// With this, you can execute the preprocessing at a later time.
+	///
+	/// @author Scribble
+	///
+	public static record CurrentFilePreprocessAction(List<String> outLines, Path inFile, Path outFile) {
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -89,15 +89,10 @@ public class TaskPreprocessWatch extends DefaultTask {
 						System.out.println("No recent file exists...\n");
 						continue;
 					}
-					Path outFile = currentFileAction.outFile();
-					List<String> outLines = currentFileAction.outLines();
-
-					Discombobulator.pathLock.scheduleAndLock(outFile);
-					Files.createDirectories(outFile.getParent());
-					SafeFileOperations.write(outFile, outLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+					TaskPreprocessWatch.runFileAction(currentFileAction);
 					currentFileAction = null;
 
-					System.out.println(String.format("Preprocessed the recently edited file %s%s%s\n", PURPLE, outFile.getFileName(), WHITE));
+					System.out.println(String.format("Preprocessed the recently edited file %s%s%s\n", PURPLE, currentFileAction.outFile().getFileName(), WHITE));
 				}
 			}
 		} catch (IOException e1) {
@@ -239,5 +234,19 @@ public class TaskPreprocessWatch extends DefaultTask {
 	/// @author Scribble
 	///
 	public static record CurrentFilePreprocessAction(List<String> outLines, Path inFile, Path outFile) {
+	}
+
+	///
+	/// Runs the {@link CurrentFilePreprocessAction}
+	///
+	/// @param currentFileAction The {@link CurrentFilePreprocessAction} to run
+	///
+	public static void runFileAction(CurrentFilePreprocessAction currentFileAction) throws IOException {
+		Path outFile = currentFileAction.outFile();
+		List<String> outLines = currentFileAction.outLines();
+
+		Discombobulator.pathLock.scheduleAndLock(outFile);
+		Files.createDirectories(outFile.getParent());
+		SafeFileOperations.write(outFile, outLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/utils/Colors.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/Colors.java
@@ -1,5 +1,7 @@
 package com.minecrafttas.discombobulator.utils;
 
+import com.minecrafttas.discombobulator.Discombobulator;
+
 public enum Colors {
 	RESET("\033[0m"),
 
@@ -76,7 +78,7 @@ public enum Colors {
 
 	@Override
 	public String toString() {
-		return ansiCode;
+		return Discombobulator.DISABLE_ANSI ? "" : ansiCode;
 	}
 
 	Colors(String ansiCode) {

--- a/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
@@ -13,7 +13,7 @@ public class LineFeedHelper {
 		} else if ("\\r\\n".equals(property) || "\r\n".equals(property)) {
 			System.out.println(String.format("Preprocessing with line seperator %s\\r\\n%s\n", YELLOW, WHITE));
 		} else {
-			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, property.equals("\r\n") ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
+			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, "\r\n".equals(property) ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
 		}
 	}
 

--- a/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
@@ -13,7 +13,7 @@ public class LineFeedHelper {
 		} else if ("\\r\\n".equals(property) || "\r\n".equals(property)) {
 			System.out.println(String.format("Preprocessing with line seperator %s\\r\\n%s\n", YELLOW, WHITE));
 		} else {
-			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, "\r\n".equals(property) ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
+			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, System.lineSeparator().equals(property) ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
 		}
 	}
 

--- a/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
@@ -1,15 +1,19 @@
 package com.minecrafttas.discombobulator.utils;
 
+import static com.minecrafttas.discombobulator.utils.Colors.GREEN;
+import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
+import static com.minecrafttas.discombobulator.utils.Colors.YELLOW;
+
 public class LineFeedHelper {
 
 	public static void printMessage() {
 		String property = System.getProperty("line.seperator");
 		if ("\\n".equals(property) || "\n".equals(property)) {
-			System.out.println("Preprocessing with line seperator \033[0;32m\\n\033[0;37m\n");
+			System.out.println(String.format("Preprocessing with line seperator %s\\n%s\n", GREEN, WHITE));
 		} else if ("\\r\\n".equals(property) || "\r\n".equals(property)) {
-			System.out.println("Preprocessing with line seperator \033[0;32m\\r\\n\033[0;37m\n");
+			System.out.println(String.format("Preprocessing with line seperator %s\\r\\n%s\n", YELLOW, WHITE));
 		} else {
-			System.out.println(String.format("Preprocessing with default line seperator \033[0;32m%s\033[0;37m\nTo change this, add \033[0;33m-Dline.seperator=\"\\n\"\033[0;37m to VM arguments\n", System.lineSeparator().equals("\r\n") ? "\\r\\n" : "\\n"));
+			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, property.equals("\r\n") ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
 		}
 	}
 

--- a/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
@@ -13,7 +13,7 @@ public class LineFeedHelper {
 		} else if ("\\r\\n".equals(property) || "\r\n".equals(property)) {
 			System.out.println(String.format("Preprocessing with line seperator %s\\r\\n%s\n", YELLOW, WHITE));
 		} else {
-			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, System.lineSeparator().equals(property) ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
+			System.out.println(String.format("Preprocessing with default line seperator %s%s%s\nTo change this, add %s-Dline.seperator=\"\\n\"%s to VM arguments\n", YELLOW, System.lineSeparator().equals("\r\n") ? "\\r\\n" : "\\n", WHITE, YELLOW, WHITE));
 		}
 	}
 

--- a/src/main/java/com/minecrafttas/discombobulator/utils/SocketLock.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/SocketLock.java
@@ -1,5 +1,8 @@
 package com.minecrafttas.discombobulator.utils;
 
+import static com.minecrafttas.discombobulator.utils.Colors.GREEN;
+import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -26,7 +29,7 @@ public class SocketLock {
 	 */
 	public SocketLock(int port) {
 		this.port = port;
-		System.out.println(String.format("Locking Port \033[0;32m%s\033[0;37m\n", port));
+		System.out.println(String.format("Locking Port %s%s%s\n", GREEN, port, WHITE));
 		try {
 			this.socket = new ServerSocket();
 		} catch (IOException e) {

--- a/src/test/java/com/minecrafttas/discombobulator/test/ProcessorTestVersionBlock.java
+++ b/src/test/java/com/minecrafttas/discombobulator/test/ProcessorTestVersionBlock.java
@@ -148,7 +148,7 @@ class ProcessorTestVersionBlock extends TestBase {
 	}
 
 	/**
-	 * TargetVersion: null Expected: All comment out
+	 * TargetVersion: null Expected: Default
 	 * 
 	 * @throws Exception
 	 */


### PR DESCRIPTION
## preprocessVersion
Up until now, only 2 main preprocessing tasks existed, `preprocessBase`, which preprocessed the code from the base folder into the version folders and `preprocessWatch` for the reverse.

However, only having `preprocessWatch` for the reverse is rather limiting. Sometimes, if you are in a creative rush, you just start coding and forget that you have to run `preprocessWatch`, so you'll end up with code from one version desynced... If that happens, you were forced to enable watch mode, then go through every file again and trigger the watcher so that it preprocesses back into the base folder.

To fix this, here is the new task `preprocessVersion`. As a counterpart to `preprocessBase`, you can run the task in a specific subproject (with `gradle :1.14.4:preprocessVersion`) and it will only preprocess that version back into the base and version folders (including the one that was recently edited so 1.14.4 as well)

This should greatly improve any users sanity.

## Gradle jank
And while I'm here I can introduce some good old gradle hacks to make this work:  
Gradle in their endless wisdom made it, so when registering a task in sub projects, it automatically creates a task in the root project, that let's you run that task in all subprojects. Really useful, but also really bad in this case...  
If you accidentally run the root task, then all subprojects want to overwrite the base folder leading to potential loss of data.
So I searched far and wide, but there seems to be no method of disabeling that root task.

But I found out, you can register a different class to this root task, so I registered a class that specifically throws an error to stop the execution of that and all following tasks. Job done.

## Disable ANSI
If you hate colors, a new build.gradle option named `disableAnsi = true` was added to stop colors completely.

## Java 23 update
Markdown in javadoc 🎉 That's it... I don't know what else was added...

## More messages
Updated messages in several places to better reflect what is happening, including a "preprocess into version *Base*" message that was missing before