### PR TITLE
Include baseFolder in watched folders for `preprocessWatch`

### DIFF
--- a/Test/Test1.12.2/build.gradle
+++ b/Test/Test1.12.2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 }
 
 java {

--- a/Test/Test1.14.4/build.gradle
+++ b/Test/Test1.14.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 }
 
 java {

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -2,6 +2,7 @@ package com.minecrafttas.discombobulator.processor;
 
 import static com.minecrafttas.discombobulator.utils.Colors.CYAN;
 import static com.minecrafttas.discombobulator.utils.Colors.PURPLE;
+import static com.minecrafttas.discombobulator.utils.Colors.PURPLE_BRIGHT;
 import static com.minecrafttas.discombobulator.utils.Colors.RED;
 import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
 import static com.minecrafttas.discombobulator.utils.Colors.YELLOW;
@@ -18,6 +19,7 @@ import java.util.Map.Entry;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 import com.minecrafttas.discombobulator.Discombobulator;
+import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch.CurrentFilePreprocessAction;
 import com.minecrafttas.discombobulator.utils.BetterFileWalker;
 import com.minecrafttas.discombobulator.utils.LineFeedHelper;

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -131,7 +131,7 @@ public class FilePreprocessor {
 			}
 
 			// Preprocess the lines
-			List<String> outLines = processor.preprocess(versionName, linesToProcess, extension);
+			List<String> outLines = processor.preprocess(versionName.equals("Base") ? null : versionName, linesToProcess, extension);
 
 			// If the version equals the original version, then skip it
 			if (targetSubSourceDir.equals(currentVersionDir)) {
@@ -139,10 +139,11 @@ public class FilePreprocessor {
 				continue;
 			}
 
-			preprocessLines(outLines, outFile, versionName, extension);
 			if (verbose) {
 				System.out.println(String.format("into version %s%s%s", CYAN, versionName, WHITE));
 			}
+			// Write lines to file
+			writeLines(outLines, outFile);
 		}
 		return out;
 	}

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -2,7 +2,6 @@ package com.minecrafttas.discombobulator.processor;
 
 import static com.minecrafttas.discombobulator.utils.Colors.CYAN;
 import static com.minecrafttas.discombobulator.utils.Colors.PURPLE;
-import static com.minecrafttas.discombobulator.utils.Colors.PURPLE_BRIGHT;
 import static com.minecrafttas.discombobulator.utils.Colors.RED;
 import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
 import static com.minecrafttas.discombobulator.utils.Colors.YELLOW;
@@ -19,7 +18,6 @@ import java.util.Map.Entry;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 import com.minecrafttas.discombobulator.Discombobulator;
-import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch.CurrentFilePreprocessAction;
 import com.minecrafttas.discombobulator.utils.BetterFileWalker;
 import com.minecrafttas.discombobulator.utils.LineFeedHelper;

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -74,8 +74,9 @@ public class TaskPreprocessWatch extends DefaultTask {
 
 		for (Entry<String, Path> versionPair : versionsConfig.entrySet()) {
 			Path subSourceDir = versionPair.getValue().resolve("src");
-			this.watch(subSourceDir, versionsConfig);
+			this.watchVersion(subSourceDir, versionsConfig);
 		}
+		//this.watchBase(versionsConfig);
 
 		// Wait for user input and cancel the task
 
@@ -104,16 +105,33 @@ public class TaskPreprocessWatch extends DefaultTask {
 	}
 
 	/**
-	 * Watches and preprocesses a source folder
+	 * Watches and preprocesses a version source folder
 	 * 
 	 * @param subSourceDir Source folder of the sub project
 	 * @param versionSet Map of versions
 	 */
-	private void watch(Path subSourceDir, Map<String, Path> versionSet) {
+	private void watchVersion(Path subSourceDir, Map<String, Path> versionSet) {
 		String version = subSourceDir.getParent().getFileName().toString();
 		FileWatcher watcher = null;
 		try {
 			watcher = constructFileWatcher(subSourceDir, versionSet, version);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		threads.add(new FileWatcherThread(watcher, version));
+	}
+
+	/**
+	 * Watches and preprocesses a version base folder
+	 * 
+	 * @param baseSourceDir Source folder of the sub project
+	 * @param versionSet Map of versions
+	 */
+	private void watchBase(Map<String, Path> versionSet) {
+		String version = baseSourceDir.getParent().getFileName().toString();
+		FileWatcher watcher = null;
+		try {
+			watcher = constructFileWatcher(baseSourceDir, versionSet, version);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -3,7 +3,9 @@ package com.minecrafttas.discombobulator.tasks;
 import static com.minecrafttas.discombobulator.utils.Colors.CYAN;
 import static com.minecrafttas.discombobulator.utils.Colors.GREEN;
 import static com.minecrafttas.discombobulator.utils.Colors.PURPLE;
+import static com.minecrafttas.discombobulator.utils.Colors.PURPLE_BRIGHT;
 import static com.minecrafttas.discombobulator.utils.Colors.RED;
+import static com.minecrafttas.discombobulator.utils.Colors.RED_BRIGHT;
 import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
 import static com.minecrafttas.discombobulator.utils.Colors.YELLOW;
 
@@ -149,7 +151,7 @@ public class TaskPreprocessWatch extends DefaultTask {
 				// Get path relative to the root dir
 				String extension = FilenameUtils.getExtension(path.getFileName().toString());
 				try {
-
+					System.out.println(String.format("[%s%s%s]", PURPLE_BRIGHT, TaskPreprocessWatch.findVersionFromPath(path, versions), WHITE));
 					// Preprocess in all sub versions
 					currentFileAction = Discombobulator.fileProcessor.preprocessVersions(path, versions, extension, subSourceDir, true);
 
@@ -172,8 +174,11 @@ public class TaskPreprocessWatch extends DefaultTask {
 				if (Discombobulator.pathLock.isLocked(path))
 					return;
 
+				String version = findVersionFromPath(path, versions);
+
 				Path relativeFile = subSourceDir.relativize(path);
 
+				System.out.println(String.format("[%s%s%s]", RED_BRIGHT, version, WHITE));
 				System.out.println(String.format("Deleting %s%s%s%s%s", relativeFile.getParent(), File.separator, RED, relativeFile.getFileName().toString(), WHITE));
 				// Delete this file in other versions too
 				// Iterate through all versions
@@ -184,12 +189,16 @@ public class TaskPreprocessWatch extends DefaultTask {
 					if (targetSourceDir.equals(subSourceDir))
 						continue;
 
-					System.out.println(String.format("from version %s%s%s", CYAN, versionPair.getKey(), WHITE));
-
 					Path targetPathToDelete = targetSourceDir.resolve(relativeFile);
 
 					Discombobulator.pathLock.scheduleAndLock(targetPathToDelete);
-					SafeFileOperations.delete(targetPathToDelete);
+
+					System.out.println(String.format("from version %s%s%s", CYAN, versionPair.getKey(), WHITE));
+					if (version.equals("Base")) {
+						SafeFileOperations.nuke(targetPathToDelete);
+					} else {
+						SafeFileOperations.delete(targetPathToDelete);
+					}
 				}
 			}
 		};
@@ -264,5 +273,14 @@ public class TaskPreprocessWatch extends DefaultTask {
 		Discombobulator.pathLock.scheduleAndLock(outFile);
 		Files.createDirectories(outFile.getParent());
 		SafeFileOperations.write(outFile, outLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+	}
+
+	public static String findVersionFromPath(Path path, Map<String, Path> versions) {
+		for (Entry<String, Path> version : versions.entrySet()) {
+			if (path.startsWith(version.getValue())) {
+				return version.getKey();
+			}
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -1,10 +1,13 @@
 package com.minecrafttas.discombobulator.tasks;
 
+import static com.minecrafttas.discombobulator.utils.Colors.CYAN;
 import static com.minecrafttas.discombobulator.utils.Colors.GREEN;
 import static com.minecrafttas.discombobulator.utils.Colors.PURPLE;
+import static com.minecrafttas.discombobulator.utils.Colors.RED;
 import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
 import static com.minecrafttas.discombobulator.utils.Colors.YELLOW;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.MalformedInputException;
 import java.nio.file.ClosedWatchServiceException;
@@ -72,6 +75,8 @@ public class TaskPreprocessWatch extends DefaultTask {
 			return;
 		}
 
+		versionsConfig.put("Base", baseProjectDir);
+
 		for (Entry<String, Path> versionPair : versionsConfig.entrySet()) {
 			Path subSourceDir = versionPair.getValue().resolve("src");
 			this.watchVersion(subSourceDir, versionsConfig);
@@ -108,33 +113,21 @@ public class TaskPreprocessWatch extends DefaultTask {
 	 * Watches and preprocesses a version source folder
 	 * 
 	 * @param subSourceDir Source folder of the sub project
-	 * @param versionSet Map of versions
+	 * @param targetSet Map of target versions
 	 */
-	private void watchVersion(Path subSourceDir, Map<String, Path> versionSet) {
+	private void watchVersion(Path subSourceDir, Map<String, Path> targetSet) {
 		String version = subSourceDir.getParent().getFileName().toString();
 		FileWatcher watcher = null;
 		try {
-			watcher = constructFileWatcher(subSourceDir, versionSet, version);
+			watcher = constructFileWatcher(subSourceDir, targetSet, version);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		threads.add(new FileWatcherThread(watcher, version));
-	}
 
-	/**
-	 * Watches and preprocesses a version base folder
-	 * 
-	 * @param baseSourceDir Source folder of the sub project
-	 * @param versionSet Map of versions
-	 */
-	private void watchBase(Map<String, Path> versionSet) {
-		String version = baseSourceDir.getParent().getFileName().toString();
-		FileWatcher watcher = null;
-		try {
-			watcher = constructFileWatcher(baseSourceDir, versionSet, version);
-		} catch (IOException e) {
-			e.printStackTrace();
+		if (version.equals(this.getProject().getName())) {
+			version = "Base";
 		}
+
 		threads.add(new FileWatcherThread(watcher, version));
 	}
 
@@ -149,21 +142,16 @@ public class TaskPreprocessWatch extends DefaultTask {
 			@Override
 			protected void onModifyFile(Path path) {
 
-				PathLock schedule = Discombobulator.pathLock;
-				if (schedule.isLocked(path))
+				PathLock pathLock = Discombobulator.pathLock;
+				if (pathLock.isLocked(path))
 					return;
 
 				// Get path relative to the root dir
-				Path relativeInFile = subSourceDir.relativize(path);
 				String extension = FilenameUtils.getExtension(path.getFileName().toString());
 				try {
 
 					// Preprocess in all sub versions
 					currentFileAction = Discombobulator.fileProcessor.preprocessVersions(path, versions, extension, subSourceDir, true);
-
-					// Preprocess in base dir
-					Path outFile = baseSourceDir.resolve(relativeInFile);
-					Discombobulator.fileProcessor.preprocessFile(path, outFile, null, extension);
 
 					if (msgSeen == false) {
 						System.out.println(Colors.YELLOW + "Type 1 to also preprocess this file" + Colors.WHITE + "\n");
@@ -180,19 +168,29 @@ public class TaskPreprocessWatch extends DefaultTask {
 
 			@Override
 			protected void onDeleteFile(Path path) {
+
+				if (Discombobulator.pathLock.isLocked(path))
+					return;
+
 				Path relativeFile = subSourceDir.relativize(path);
+
+				System.out.println(String.format("Deleting %s%s%s%s%s", relativeFile.getParent(), File.separator, RED, relativeFile.getFileName().toString(), WHITE));
 				// Delete this file in other versions too
 				// Iterate through all versions
 				for (Entry<String, Path> versionPair : versions.entrySet()) {
 					Path targetProject = versionPair.getValue();
+					Path targetSourceDir = targetProject.resolve("src");
 
-					if (targetProject.equals(subSourceDir))
+					if (targetSourceDir.equals(subSourceDir))
 						continue;
 
-					SafeFileOperations.delete(targetProject.resolve(relativeFile));
+					System.out.println(String.format("from version %s%s%s", CYAN, versionPair.getKey(), WHITE));
+
+					Path targetPathToDelete = targetSourceDir.resolve(relativeFile);
+
+					Discombobulator.pathLock.scheduleAndLock(targetPathToDelete);
+					SafeFileOperations.delete(targetPathToDelete);
 				}
-				// Delete this file in base project
-				SafeFileOperations.delete(baseSourceDir.resolve(relativeFile));
 			}
 		};
 	}

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -44,11 +44,6 @@ public class TaskPreprocessWatch extends DefaultTask {
 	private List<FileWatcherThread> threads = new ArrayList<>();
 
 	private CurrentFilePreprocessAction currentFileAction = null;
-	/**
-	 * <p>The source dir in the base project that is used for version control<br>
-	 * <code>rootdir/src</code>
-	 */
-	private Path baseSourceDir;
 
 	private boolean msgSeen = false;
 
@@ -61,7 +56,6 @@ public class TaskPreprocessWatch extends DefaultTask {
 
 		// Prepare list of physical version folders
 		Path baseProjectDir = this.getProject().getProjectDir().toPath();
-		baseSourceDir = baseProjectDir.resolve("src");
 
 		LineFeedHelper.printMessage();
 
@@ -198,6 +192,22 @@ public class TaskPreprocessWatch extends DefaultTask {
 						SafeFileOperations.nuke(targetPathToDelete);
 					} else {
 						SafeFileOperations.delete(targetPathToDelete);
+					}
+
+					Path parentDir = targetPathToDelete.getParent();
+					boolean isEmpty;
+					try {
+						isEmpty = Files.isDirectory(parentDir) && Files.list(parentDir).count() == 0L;
+					} catch (IOException e) {
+						e.printStackTrace();
+						return;
+					}
+					if (isEmpty) {
+						if (version.equals("Base")) {
+							SafeFileOperations.nuke(parentDir);
+						} else {
+							SafeFileOperations.delete(parentDir);
+						}
 					}
 				}
 			}

--- a/src/main/java/com/minecrafttas/discombobulator/utils/SafeFileOperations.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/SafeFileOperations.java
@@ -35,6 +35,21 @@ public class SafeFileOperations {
 			}
 	}
 
+	///
+	/// For the times when you don't want to fill your trashbin, do the opposite of "safe"
+	///
+	public static void nuke(Path file) {
+		if (!Files.exists(file)) {
+			Discombobulator.printError("Can't nuke file as it does not exist: " + file);
+			return;
+		}
+		try {
+			Files.delete(file);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
 	/**
 	 * Writes to a file but clears it first
 	 * @param path File to write to

--- a/src/main/java/com/minecrafttas/discombobulator/utils/SafeFileOperations.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/SafeFileOperations.java
@@ -8,6 +8,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 
+import com.minecrafttas.discombobulator.Discombobulator;
+
 /**
  * Safety improvements to some file operations
  * @author Pancake
@@ -19,8 +21,10 @@ public class SafeFileOperations {
 	 * @param file The file to remove
 	 */
 	public static void delete(Path file) {
-		if (!Files.exists(file))
+		if (!Files.exists(file)) {
+			Discombobulator.printError("Can't delete file as it does not exist: " + file);
 			return;
+		}
 		if (Desktop.isDesktopSupported())
 			Desktop.getDesktop().moveToTrash(file.toFile());
 		else


### PR DESCRIPTION
Another common pain point I found was when having `preprocessWatch` active, then trying to checkout a different commit in git.

Since preprocessWatch doesn't watch the base folder, this change will go unnoticed by the preprocessor, forcing you to close `preprocessWatch`, run `preprocessBase` then again run preprocessWatch to have the correct version again... And when looking for errors in the commits, this is quite frustrating.

## Changes
### preprocessWatch
The change by itself was surprisingly simple, just put the base project directory into the [versionConfig](https://github.com/MinecraftTAS/Discombobulator/pull/30/files#diff-736f77302130cdac3fa39920a31b5b719e29b8e0d8d3dba08c7b647bc4d15e7cR74) and handle a couple of cases where we have to check for the "Base" version.  

### Delete in preprocessWatch
While I was at it, I also improved the deletion code in preprocessWatch, so that is actually works properly, including the ability to delete empty folders/packages when the last file in the package gets deleted. I also added a "nuke" method that ignores the "move to trash" feature of SafeFileOperations. This is only active when preprocessing from the base folder, as that folder is also watched by VCS. And I noticed that git loves to sometimes delete the entire file and readd it, which will fill up the trash bin on windows with bigger projects

### More console hints
As with all of my PRs lately I also added more hints... This includes a warning if the file you want to delete doesn't exist, which I added for *no paricular reason*... Also added a [1.14.4] before preprocess actions to indicate what version we are preprocessing from
![WindowsTerminal_r0woUfLl6t](https://github.com/user-attachments/assets/bdb428f9-0bfa-4d28-9e4f-2f3fb13898d4)
Pretty sure this will look better in your terminal, I messed with my colors a bit...