### PR TITLE
Switch repo to maven.minecrafttas.com

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,0 +1,28 @@
+# Publish Main to https://maven.minecrafttas.com/main
+name: Publish Main
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'MinecraftTAS/Discombobulator'
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 23 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '23'
+        distribution: 'temurin'
+        architecture: x64
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-version: 8.13
+    - name: Publish
+      run: gradle publishAllPublicationsToMinecrafttasMainRepository
+      env:
+        MAVEN_NAME: ${{ secrets.MAVEN_NAME }}
+        MAVEN_SECRET: ${{ secrets.MAVEN_SECRET }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,26 @@
+# Publish snapshot to https://maven.minecrafttas.com/snapshots
+name: Publish Snapshot
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'MinecraftTAS/Discombobulator'
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 23 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '23'
+        distribution: 'temurin'
+        architecture: x64
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-version: 8.13
+    - name: Publish
+      run: gradle publishAllPublicationsToMinecrafttasSnapshotsRepository
+      env:
+        MAVEN_NAME: ${{ secrets.MAVEN_NAME }}
+        MAVEN_SECRET: ${{ secrets.MAVEN_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        gradle-version: 8.12.1
+        gradle-version: 8.13
     - name: Build
       run: gradle build
     - name: Upload Test Report

--- a/Test/settings.gradle
+++ b/Test/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
 	repositories {
 		mavenLocal() // For development purposes
 		mavenCentral()
-		maven { url = "https://maven.mgnet.work/main" }
+		maven { url = "https://maven.minecrafttas.com/main" }
 		maven { url = "https://maven.fabricmc.net" }
 		gradlePluginPortal()
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ test {
 publishing {
 	repositories {
 		maven {
-			name = "mgnetwork"
-			url = "https://maven.mgnet.work/main"
+			name = "minecrafttas"
+			url = "https://maven.minecrafttas.com/main"
 			credentials(PasswordCredentials)
 			authentication {
 				basic(BasicAuthentication)

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 sourceCompatibility = targetCompatibility = 23
 
 // Name, version and group for the project
-version = "1.3-SNAPSHOT"
+version = "1.3"
 group = "com.minecrafttas"
 archivesBaseName = "discombobulator"
 
@@ -39,10 +39,28 @@ test {
 	}
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+javadoc {
+	options.locale = "en_US"
+}
+
 publishing {
 	repositories {
 		maven {
-			name = "minecrafttas"
+			version = version + "-SNAPSHOT"
+			name = "minecrafttasSnapshots"
+			url = "https://maven.minecrafttas.com/snapshots"
+			credentials(PasswordCredentials)
+			authentication {
+				basic(BasicAuthentication)
+			}
+		}
+		maven {
+			name = "minecrafttasMain"
 			url = "https://maven.minecrafttas.com/main"
 			credentials(PasswordCredentials)
 			authentication {

--- a/src/main/java/com/minecrafttas/discombobulator/processor/LinePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/LinePreprocessor.java
@@ -10,7 +10,8 @@ import java.util.regex.Pattern;
 
 import com.minecrafttas.discombobulator.utils.Pair;
 
-/*Welcome to the madness that is this preprocessor. Here I will try as best as I can to explain how this works.
+/*
+ * Welcome to the madness that is this preprocessor. Here I will try as best as I can to explain how this works.
  * Why am I explaining it? Because my hope is, that at least I can remember what the hell I was doing when I made this
  * 
  * Start of with the "preprocess" method which is the only public method here.
@@ -48,7 +49,7 @@ public class LinePreprocessor {
 	 * "1.20",
 	 * "1.19",
 	 * "1.18",
-	 * "1.16" <- default version since it's the lowest
+	 * "1.16" &lt;- default version since it's the lowest
 	 * ]
 	 * </pre>
 	 * @param versions The versions to check for in an order
@@ -64,7 +65,7 @@ public class LinePreprocessor {
 	 * 
 	 * <pre>
 	 * [
-	 * "1.20", <- default version since it's the highest
+	 * "1.20", &lt;- default version since it's the highest
 	 * "1.19",
 	 * "1.18",
 	 * "1.16"
@@ -83,7 +84,7 @@ public class LinePreprocessor {
 	}
 
 	/**
-	 * Preprocesses the lines to a targeted version.
+	 * <p>Preprocesses the lines to a targeted version.
 	 * <p>Preprocessing can happen in 2 ways:<br>
 	 * <ol>
 	 * <li>Preprocessing a block of code</li>
@@ -91,7 +92,7 @@ public class LinePreprocessor {
 	 * </ol>
 	 * <p>The advantage of pattern processing is that you can save yourself some work making a version block for common patterns like <code>Minecraft.getMinecraft().player</code> in 1.12 to <code>Minecraft.getMinecraft().thePlayer</code> in e.g. 1.10
 	 *
-	 * <h2>VersionBlock</h2>
+	 * <h4>VersionBlock</h4>
 	 * <p>A version block allows you to uncomment part of the code in certain versions via comments:
 	 * <pre>
 	 * //# 1.12.2
@@ -107,7 +108,7 @@ public class LinePreprocessor {
 	 * 
 	 * <p>You can define these blocks out of order (e.g. first 1.9.4 then 1.12.2)... The version order is ultimately defined in the build.gradle.
 	 * 
-	 * <h3>Nesting</h3>
+	 * <h5>Nesting</h5>
 	 * 
 	 * <p>Sometimes you have a lot of changes in one version but a tiny amount is added in the following versions. In these cases, you would need to copy all the large changes again into the newest version:
 	 * 
@@ -139,9 +140,9 @@ public class LinePreprocessor {
 	 * than the changes in
 	 * 1.16.5
 	 * 
-	 * //## 1.16.5		<-- 2 hashtags define the nested version
+	 * //## 1.16.5		&lt;-- 2 hashtags define the nested version
 	 * New things in 1.16.5
-	 * //## end		<-- The end of the nested block is defined with 2 hashtags as well
+	 * //## end		&lt;-- The end of the nested block is defined with 2 hashtags as well
 	 * 
 	 * //# end
 	 * </pre>
@@ -157,7 +158,7 @@ public class LinePreprocessor {
 	 * <li>Using def in a nested block will use the parent version</li>
 	 * </ul>
 	 * 
-	 * <h2>Patterns</h2>
+	 * <h4>Patterns</h4>
 	 * Patterns are defined in the build.gradle:
 	 * 
 	 * <pre>
@@ -186,7 +187,7 @@ public class LinePreprocessor {
 	 * 
 	 * @param targetVersion The version for which lines should be enabled
 	 * @param lines The lines to preprocess
-	 * @param filename Debug filename for errors during preprocessing
+	 * @param fileending The fileending of the preprocess file for applying different comment types
 	 * @return The preprocessed lines of the file
 	 * @throws Exception 
 	 */
@@ -253,7 +254,7 @@ public class LinePreprocessor {
 	 * Generates a list of version blocks by prereading the block. To take nesting into account, it generates the lists recursively. Most of the error checking is done here.
 	 * <pre>
 	 * 1.16.1
-	 * 	1.16.5	<- (Nested versions)
+	 * 	1.16.5	&lt;- (Nested versions)
 	 * 	1.17.1
 	 * 	end
 	 * 1.18.1
@@ -285,7 +286,7 @@ public class LinePreprocessor {
 	 * </pre>
 	 * <p>Note that the last end has to be true, since everything outside a version block list is enabled by default
 	 * <pre>
-	 * public void example() {	<-Outside a block, so line is not commented out by default
+	 * public void example() {	&lt;-Outside a block, so line is not commented out by default
 	 * // # 1.16.1
 	 * //CODE!
 	 * // # end


### PR DESCRIPTION
## Changes
Publish new things on https://maven.minecrafttas.com/#/main
## Workflows
- [x] Add workflow for merging into develop to publish the snapshot
- [x] Add workflow for releasing to publish main and snapshot
## Fixes
- Javadoc errors
## Javadoc
So I had problems with javadoc not displaying in english... Well my bet is that the github servers are running in the US so I think I don't have this problem... Maybe linux also adheres to the locale option...