### PR TITLE
Fix non-preprocessable files not being copied

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.3
+version=1.3.1
 release=false

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -94,6 +94,7 @@ public class FilePreprocessor {
 
 		if (fileFilter != null && fileFilter.accept(inFile.toFile())) {
 			System.out.println(String.format("Ignoring %s%s%s", YELLOW, inFile.getFileName().toString(), WHITE));
+			Files.createDirectories(outFile.getParent());
 			Files.copy(inFile, outFile, StandardCopyOption.REPLACE_EXISTING);
 			return;
 		}

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -144,6 +144,7 @@ public class FilePreprocessor {
 					System.out.println(String.format("into version %s%s%s", CYAN, versionName, WHITE));
 				}
 				System.out.println(String.format("Ignoring %s%s%s", YELLOW, inFile.getFileName().toString(), WHITE));
+				Files.createDirectories(outFile.getParent());
 				Files.copy(inFile, outFile, StandardCopyOption.REPLACE_EXISTING);
 				continue;
 			}


### PR DESCRIPTION
Fixes non-preprocessable files (a.k.a ignored files) not being copied to the target folder due to the directories not existing first

- Bump version