### PR TITLE
Update to Gradle 9 & Java 25

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -11,15 +11,15 @@ jobs:
     if: github.repository == 'MinecraftTAS/Discombobulator'
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 23 for x64
+    - name: Set up JDK 25 for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '23'
+        java-version: '25'
         distribution: 'temurin'
         architecture: x64
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
-        gradle-version: 8.13
+        gradle-version: 9.2.1
     - name: Publish
       run: gradle publishAllPublicationsToMinecrafttasMainRepository -Prelease=true -PminecrafttasMainUsername=${{ secrets.MAVEN_NAME }} -PminecrafttasMainPassword=${{ secrets.MAVEN_SECRET }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,15 +9,15 @@ jobs:
     if: github.repository == 'MinecraftTAS/Discombobulator'
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 23 for x64
+    - name: Set up JDK 25 for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '23'
+        java-version: '25'
         distribution: 'temurin'
         architecture: x64
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
-        gradle-version: 8.13
+        gradle-version: 9.2.1
     - name: Publish
       run: gradle publishAllPublicationsToMinecrafttasSnapshotsRepository -PminecrafttasSnapshotsUsername=${{ secrets.MAVEN_NAME }} -PminecrafttasSnapshotsPassword=${{ secrets.MAVEN_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 23 for x64
+    - name: Set up JDK 25 for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '23'
+        java-version: '25'
         distribution: 'temurin'
         architecture: x64
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        gradle-version: 8.13
+        gradle-version: 9.2.1
     - name: Build
       run: gradle build
     - name: Upload Test Report

--- a/Test/Test1.12.2/build.gradle
+++ b/Test/Test1.12.2/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id "legacy-looming" version "1.14-SNAPSHOT"
 }
 
 java {
@@ -8,11 +9,11 @@ java {
 
 repositories {
 	//mavenLocal()
-	maven { url 'https://raw.githubusercontent.com/BleachDev/cursed-mappings/main/' }
+	maven { url = 'https://raw.githubusercontent.com/BleachDev/cursed-mappings/main/' }
 }
 
 dependencies {
 	minecraft "com.mojang:minecraft:1.12.2"
 	mappings "net.legacyfabric:yarn:1.12.2+build.mcp"
-	modImplementation "net.fabricmc:fabric-loader:0.16.9"
+	modImplementation "net.fabricmc:fabric-loader:0.18.2"
 }

--- a/Test/Test1.14.4/build.gradle
+++ b/Test/Test1.14.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'fabric-loom' version '1.14-SNAPSHOT'
 }
 
 java {
@@ -9,5 +9,5 @@ java {
 dependencies {
 	minecraft "com.mojang:minecraft:1.14.4"
 	mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:0.16.9"
+	modImplementation "net.fabricmc:fabric-loader:0.18.2"
 }

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'discombobulator' version '1.3-SNAPSHOT'
+	id 'discombobulator' version "1.4-SNAPSHOT"
 }
 
 discombobulator {

--- a/Test/gradle.properties
+++ b/Test/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx6G
+org.gradle.configuration-cache=true
+org.gradle.warning.mode=fail

--- a/Test/settings.gradle
+++ b/Test/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
 		mavenCentral()
 		maven { url = "https://maven.minecrafttas.com/main" }
 		maven { url = "https://maven.fabricmc.net" }
-		maven {	url = "https://maven.legacyfabric.net/" }
+		maven { url = "https://maven.legacyfabric.net/" }
 		gradlePluginPortal()
 	}
 }

--- a/Test/settings.gradle
+++ b/Test/settings.gradle
@@ -4,6 +4,7 @@ pluginManagement {
 		mavenCentral()
 		maven { url = "https://maven.minecrafttas.com/main" }
 		maven { url = "https://maven.fabricmc.net" }
+		maven {	url = "https://maven.legacyfabric.net/" }
 		gradlePluginPortal()
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ test {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_25
-	targetCompatibility = JavaVersion.VERSION_25
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 	withSourcesJar()
 	withJavadocJar()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,13 @@ plugins {
 	id 'maven-publish'
 }
 
-// Change java compatibility level to 23
-sourceCompatibility = targetCompatibility = 23
-
 def snapshot = project.release=="true" ? "" : "-SNAPSHOT"
 version = project.version+snapshot
 // Name, version and group for the project
 group = "com.minecrafttas"
-archivesBaseName = "discombobulator"
+base {
+	archivesName = "discombobulator"
+}
 
 // Configure the gradle plugin
 gradlePlugin {
@@ -28,9 +27,10 @@ repositories {
 }
 
 dependencies {
-	testImplementation(platform('org.junit:junit-bom:5.11.3'))
+	testImplementation(platform('org.junit:junit-bom:6.0.1'))
 	testImplementation('org.junit.jupiter:junit-jupiter')
-	implementation 'commons-io:commons-io:2.17.0'
+	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+	implementation 'commons-io:commons-io:2.21.0'
 }
 
 test {
@@ -41,6 +41,8 @@ test {
 }
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
     withSourcesJar()
     withJavadocJar()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Plugins used in the project
 plugins {
-    id 'java-gradle-plugin'
+	id 'java-gradle-plugin'
 	id 'maven-publish'
 }
 
@@ -14,12 +14,12 @@ base {
 
 // Configure the gradle plugin
 gradlePlugin {
-    plugins {
-        discombobulator {
-            id = 'discombobulator'
-            implementationClass = 'com.minecrafttas.discombobulator.Discombobulator'
-        }
-    }
+	plugins {
+		discombobulator {
+			id = 'discombobulator'
+			implementationClass = 'com.minecrafttas.discombobulator.Discombobulator'
+		}
+	}
 }
 
 repositories {
@@ -41,10 +41,10 @@ test {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_25
+	sourceCompatibility = JavaVersion.VERSION_25
 	targetCompatibility = JavaVersion.VERSION_25
-    withSourcesJar()
-    withJavadocJar()
+	withSourcesJar()
+	withJavadocJar()
 }
 
 javadoc {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
-version=1.3.1
+version=1.4
 release=false
+org.gradle.configuration-cache=true

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -1,16 +1,5 @@
 package com.minecrafttas.discombobulator;
 
-import static com.minecrafttas.discombobulator.utils.Colors.BLUE;
-import static com.minecrafttas.discombobulator.utils.Colors.CYAN;
-import static com.minecrafttas.discombobulator.utils.Colors.GREEN;
-import static com.minecrafttas.discombobulator.utils.Colors.GREEN_BRIGHT;
-import static com.minecrafttas.discombobulator.utils.Colors.PURPLE;
-import static com.minecrafttas.discombobulator.utils.Colors.PURPLE_BRIGHT;
-import static com.minecrafttas.discombobulator.utils.Colors.RED;
-import static com.minecrafttas.discombobulator.utils.Colors.RED_BRIGHT;
-import static com.minecrafttas.discombobulator.utils.Colors.WHITE;
-import static com.minecrafttas.discombobulator.utils.Colors.YELLOW;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -137,7 +126,7 @@ public class Discombobulator implements Plugin<Project> {
 
 	public static String getSplash() {
 		return "\n" + (DISABLE_ANSI ? getColorLessSplash() : getColoredSplash()) + "\n\n"
-				+ getCenterText(String.format("%sC%so%sl%so%sr%sf%su%sl%s!%s", RED, RED_BRIGHT, YELLOW, GREEN_BRIGHT, GREEN, CYAN, BLUE, PURPLE, PURPLE_BRIGHT, WHITE), 9) + "\n"
+				+ getCenterText(String.format("Now using %sGradle 9", Colors.PURPLE), 9) + "\n"
 				+ "		Created by Pancake and Scribble\n" + getCenterText(discoVersion) + "\n\n";
 
 	}

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -3,6 +3,7 @@ package com.minecrafttas.discombobulator;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,21 +34,50 @@ import com.minecrafttas.discombobulator.utils.PathLock;
  */
 public class Discombobulator implements Plugin<Project> {
 
-	/**
-	 * Which port to lock
-	 */
+	///
+	/// Which port to lock
+	/// 
 	public static int PORT_LOCK = 8762;
 
+	///
+	/// The config set in the build.gradle file of the discombobulator
+	/// 
 	public static PreprocessingConfiguration config;
 
+	///
+	/// If true: Disables color output in the console
+	/// 
 	public static boolean DISABLE_ANSI = false;
 
+	///
+	/// Whether to use Windows or Unix style line feeds
+	/// 
 	public static String DEFAULT_LINE_FEED = System.lineSeparator();
 
+	///
+	/// The base dir of the project
+	/// 
+	public static Path BASE_PROJECT_DIR;
+
+	///
+	/// The base build directory, usually {@link #BASE_PROJECT_DIR}/build
+	/// 
+	public static Path BUILD_DIR;
+
+	///
+	/// The {@link FilePreprocessor}
+	/// 
 	public static FilePreprocessor fileProcessor;
 
+	///
+	/// The {@link PathLock}
+	/// 
 	public static PathLock pathLock;
 
+	///
+	/// The version of Discombobulator,
+	/// used for the splash in the console
+	/// 
 	private static String discoVersion;
 
 	/**
@@ -61,27 +91,42 @@ public class Discombobulator implements Plugin<Project> {
 		pathLock = new PathLock();
 
 		// Register tasks
+
+		/// preprocessBase	///
 		TaskPreprocessBase baseTask = project.getTasks().register("preprocessBase", TaskPreprocessBase.class).get();
 		baseTask.setGroup("discombobulator");
 		baseTask.setDescription("Split base source into seperate version folders");
 
+		/// preprocessWatch	///
 		TaskPreprocessWatch watchTask = project.getTasks().register("preprocessWatch", TaskPreprocessWatch.class).get();
 		watchTask.setGroup("discombobulator");
 		watchTask.setDescription("Starts a watch session. Preprocesses files into other versions on file change.");
+		watchTask.setProperty("projectName", project.getName());
 
+		/// collectBuilds	///
 		TaskCollectBuilds collectBuilds = project.getTasks().register("collectBuilds", TaskCollectBuilds.class).get();
 		collectBuilds.setGroup("discombobulator");
 		collectBuilds.setDescription("Builds, then collects all versions in root/build");
 
-		List<Task> compileTasks = new ArrayList<>();
+		List<Task> compileTaskList = new ArrayList<>();
+		Map<String, Path> buildDirs = new HashMap<>();
 		for (Project subProject : project.getSubprojects()) {
-			compileTasks.add(subProject.getTasksByName("remapJar", false).iterator().next());
+			Task compileTask = subProject.getTasksByName("remapJar", false).iterator().next();
+			compileTaskList.add(compileTask);
+
+			buildDirs.put(subProject.getName(), getBuildDir(subProject).resolve("libs"));
+		}
+		collectBuilds.setDependsOn(compileTaskList);
+		collectBuilds.setProperty("buildDirectories", buildDirs);
+
+		/// preprocessVersion ///
+		for (Project subProject : project.getSubprojects()) {
 			// Register preprocessVersion task in subProjects
 			TaskPreprocessVersion versionTask = subProject.getTasks().register("preprocessVersion", TaskPreprocessVersion.class).get();
+			versionTask.setProperty("versionDirectory", subProject.getProjectDir());
 			versionTask.setGroup("discombobulator");
 			versionTask.setDescription("Preprocesses this version back to the base folder and to versions other than this one");
 		}
-		collectBuilds.updateCompileTasks(compileTasks);
 
 		// Register preprocessVersion task in root
 		TaskPreprocessVersionError versionTaskRoot = project.getTasks().register("preprocessVersion", TaskPreprocessVersionError.class).get();
@@ -93,11 +138,12 @@ public class Discombobulator implements Plugin<Project> {
 			PORT_LOCK = config.getPort().getOrElse(8762);
 			DISABLE_ANSI = config.getDisableAnsi().getOrElse(false);
 			DEFAULT_LINE_FEED = config.getDefaultLineFeed().getOrElse(System.lineSeparator());
+			BASE_PROJECT_DIR = _project.getProjectDir().toPath();
+			BUILD_DIR = getBuildDir(_project);
 
 			Map<String, Path> versionPairs = null;
-			Path projectDir = _project.getProjectDir().toPath();
 			try {
-				versionPairs = getVersionPairs(projectDir);
+				versionPairs = getVersionPairs(BASE_PROJECT_DIR);
 			} catch (Exception e) {
 				if (e.getMessage() != null && !e.getMessage().isEmpty()) {
 					printError(e.getMessage());
@@ -126,8 +172,9 @@ public class Discombobulator implements Plugin<Project> {
 
 	public static String getSplash() {
 		return "\n" + (DISABLE_ANSI ? getColorLessSplash() : getColoredSplash()) + "\n\n"
-				+ getCenterText(String.format("Now using %sGradle 9", Colors.PURPLE), 9) + "\n"
-				+ "		Created by Pancake and Scribble\n" + getCenterText(discoVersion) + "\n\n";
+				+ getCenterText(String.format("Enable configuration cache today!")) + "\n"
+				+ getCenterText("Created by Pancake and Scribble") + "\n"
+				+ getCenterText(discoVersion) + "\n\n";
 
 	}
 
@@ -160,6 +207,14 @@ public class Discombobulator implements Plugin<Project> {
 	private static String getCenterText(String text) {
 		int length = text.length();
 		return getCenterText(text, length);
+	}
+
+	/**
+	 * @param project The project to use
+	 * @return The build directory from the project
+	 */
+	public static Path getBuildDir(Project project) {
+		return project.getLayout().getBuildDirectory().get().getAsFile().toPath();
 	}
 
 	/**

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -34,50 +34,50 @@ import com.minecrafttas.discombobulator.utils.PathLock;
  */
 public class Discombobulator implements Plugin<Project> {
 
-	///
-	/// Which port to lock
-	/// 
+	/**
+	 * Which port to lock
+	 */
 	public static int PORT_LOCK = 8762;
 
-	///
-	/// The config set in the build.gradle file of the discombobulator
-	/// 
+	/**
+	 * The config set in the build.gradle file of the discombobulator
+	 */
 	public static PreprocessingConfiguration config;
 
-	///
-	/// If true: Disables color output in the console
-	/// 
+	/**
+	 * If true: Disables color output in the console
+	 */
 	public static boolean DISABLE_ANSI = false;
 
-	///
-	/// Whether to use Windows or Unix style line feeds
-	/// 
+	/**
+	 * Whether to use Windows or Unix style line feeds
+	 */
 	public static String DEFAULT_LINE_FEED = System.lineSeparator();
 
-	///
-	/// The base dir of the project
-	/// 
+	/**
+	 * The base dir of the project
+	 */
 	public static Path BASE_PROJECT_DIR;
 
-	///
-	/// The base build directory, usually {@link #BASE_PROJECT_DIR}/build
-	/// 
+	/**
+	 * The base build directory, usually {@link #BASE_PROJECT_DIR}/build
+	 */
 	public static Path BUILD_DIR;
 
-	///
-	/// The {@link FilePreprocessor}
-	/// 
+	/**
+	 * The {@link FilePreprocessor}
+	 */
 	public static FilePreprocessor fileProcessor;
 
-	///
-	/// The {@link PathLock}
-	/// 
+	/**
+	 * The {@link PathLock}
+	 */
 	public static PathLock pathLock;
 
-	///
-	/// The version of Discombobulator,
-	/// used for the splash in the console
-	/// 
+	/**
+	 * The version of Discombobulator,
+	 * used for the splash in the console
+	 */
 	private static String discoVersion;
 
 	/**
@@ -92,18 +92,18 @@ public class Discombobulator implements Plugin<Project> {
 
 		// Register tasks
 
-		/// preprocessBase	///
+		/* preprocessBase */
 		TaskPreprocessBase baseTask = project.getTasks().register("preprocessBase", TaskPreprocessBase.class).get();
 		baseTask.setGroup("discombobulator");
 		baseTask.setDescription("Split base source into seperate version folders");
 
-		/// preprocessWatch	///
+		/* preprocessWatch */
 		TaskPreprocessWatch watchTask = project.getTasks().register("preprocessWatch", TaskPreprocessWatch.class).get();
 		watchTask.setGroup("discombobulator");
 		watchTask.setDescription("Starts a watch session. Preprocesses files into other versions on file change.");
 		watchTask.setProperty("projectName", project.getName());
 
-		/// collectBuilds	///
+		/* collectBuilds */
 		TaskCollectBuilds collectBuilds = project.getTasks().register("collectBuilds", TaskCollectBuilds.class).get();
 		collectBuilds.setGroup("discombobulator");
 		collectBuilds.setDescription("Builds, then collects all versions in root/build");
@@ -119,7 +119,7 @@ public class Discombobulator implements Plugin<Project> {
 		collectBuilds.setDependsOn(compileTaskList);
 		collectBuilds.setProperty("buildDirectories", buildDirs);
 
-		/// preprocessVersion ///
+		/* preprocessVersion */
 		for (Project subProject : project.getSubprojects()) {
 			// Register preprocessVersion task in subProjects
 			TaskPreprocessVersion versionTask = subProject.getTasks().register("preprocessVersion", TaskPreprocessVersion.class).get();

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -183,15 +183,16 @@ public class FilePreprocessor {
 		return lines;
 	}
 
-	///
-	/// 1. Locks the file to stop the filewatcher from detecting it
-	/// 2. Creates any missing directories
-	/// 3. Writes the lines with the line feed specified by the `line.seperator` system property
-	///
-	/// @param inLines
-	/// @param outFile
-	/// @throws Exception
-	///
+	/**
+	 * <ol>
+	 * <li>Locks the file to stop the filewatcher from detecting it</li>
+	 * <li>Creates any missing directories</li>
+	 * <li>Writes the lines with the line feed specified by the `line.seperator` system property</li>
+	 * </ol>
+	 * @param inLines
+	 * @param outFile
+	 * @throws Exception
+	 */
 	private void writeLines(List<String> inLines, Path outFile) throws Exception {
 		// Lock the file
 		Discombobulator.pathLock.scheduleAndLock(outFile);

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskCollectBuilds.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskCollectBuilds.java
@@ -4,35 +4,35 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
-import org.gradle.api.Task;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+
+import com.minecrafttas.discombobulator.Discombobulator;
 
 /**
  * Builds and moves all built versions into one directory for easier access
  * 
  * @author Pancake
  */
-public class TaskCollectBuilds extends DefaultTask {
+public abstract class TaskCollectBuilds extends DefaultTask {
 
 	/**
 	 * List of all build dirs
 	 */
-	private Map<String, Path> buildDirs = new HashMap<>();
+	@Input
+	abstract MapProperty<String, Path> getBuildDirectories();
 
 	/**
 	 * The main task component
 	 */
 	@TaskAction
 	public void collectBuilds() {
-		Path collectDir = getBuildDir(getProject());
+		Path collectDir = Discombobulator.BUILD_DIR;
 
 		try {
 			if (!Files.exists(collectDir))
@@ -42,7 +42,7 @@ public class TaskCollectBuilds extends DefaultTask {
 			return;
 		}
 
-		for (Entry<String, Path> entry : buildDirs.entrySet()) {
+		for (Entry<String, Path> entry : getBuildDirectories().get().entrySet()) {
 			Path buildDir = entry.getValue();
 			Stream<Path> stream;
 
@@ -66,26 +66,5 @@ public class TaskCollectBuilds extends DefaultTask {
 
 			stream.close();
 		}
-	}
-
-	/**
-	 * Updates this task with all compile tasks
-	 * 
-	 * @param compileTasks List of compile tasks
-	 */
-	public void updateCompileTasks(List<Task> compileTasks) {
-		for (Task task : compileTasks) {
-			Project project = task.getProject();
-			this.buildDirs.put(project.getName(), getBuildDir(project).resolve("libs"));
-		}
-		this.setDependsOn(compileTasks);
-	}
-
-	/**
-	 * @param project The project to use
-	 * @return The build directory from the project
-	 */
-	private Path getBuildDir(Project project) {
-		return project.getLayout().getBuildDirectory().get().getAsFile().toPath();
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessBase.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessBase.java
@@ -42,7 +42,7 @@ public class TaskPreprocessBase extends DefaultTask {
 		lock.tryLock();
 
 		// Prepare list of physical version folders
-		Path baseProjectDir = this.getProject().getProjectDir().toPath();
+		Path baseProjectDir = Discombobulator.BASE_PROJECT_DIR;
 		Map<String, Path> versionsConfig;
 		try {
 			versionsConfig = Discombobulator.getVersionPairs(baseProjectDir);

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -11,6 +11,8 @@ import java.util.Map.Entry;
 
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import com.minecrafttas.discombobulator.Discombobulator;
@@ -33,7 +35,10 @@ import com.minecrafttas.discombobulator.utils.PortLock;
  * 
  * @author Scribble
  */
-public class TaskPreprocessVersion extends DefaultTask {
+public abstract class TaskPreprocessVersion extends DefaultTask {
+
+	@InputDirectory
+	abstract DirectoryProperty getVersionDirectory();
 
 	@TaskAction
 	public void preprocessVersion() throws Exception {
@@ -44,7 +49,7 @@ public class TaskPreprocessVersion extends DefaultTask {
 		lock.tryLock();
 
 		// Prepare list of physical version folders
-		Path baseProjectDir = this.getProject().getParent().getProjectDir().toPath();
+		Path baseProjectDir = Discombobulator.BASE_PROJECT_DIR;
 		Path baseSourceDir = baseProjectDir.resolve("src");
 
 		Map<String, Path> versionsConfig;
@@ -59,7 +64,7 @@ public class TaskPreprocessVersion extends DefaultTask {
 			return;
 		}
 
-		Path versionProjectDir = this.getProject().getProjectDir().toPath();
+		Path versionProjectDir = getVersionDirectory().get().getAsFile().toPath();
 		Pair<String, Path> masterVersion = null;
 		// Find current version in version config
 

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -264,22 +264,25 @@ public abstract class TaskPreprocessWatch extends DefaultTask {
 		}
 	}
 
-	/// Stores data used for preprocessing the file that was edited most recently.
-	///
-	/// This fixes an issue where the IDE will behave weirdly, when trying to
-	/// preprocess and replace a file, that is currently being worked on. So when
-	/// saving a file, The file watcher would also replace the file that you just
-	/// saved, leading to discrepancies and annoyances.
-	///
-	/// With this, you can execute the preprocessing at a later time.
-	///
-	/// @author Scribble ///
+	/**
+	 *  Stores data used for preprocessing the file that was edited most recently.
+	 *
+	 * This fixes an issue where the IDE will behave weirdly, when trying to
+	 * preprocess and replace a file, that is currently being worked on. So when
+	 * saving a file, The file watcher would also replace the file that you just
+	 * saved, leading to discrepancies and annoyances.
+	 *
+	 * With this, you can execute the preprocessing at a later time.
+	 *
+	 * @author Scribble
+	 */
 	public static record CurrentFilePreprocessAction(List<String> outLines, Path inFile, Path outFile) {
 	}
 
-	/// Runs the {@link CurrentFilePreprocessAction}
-	///
-	/// @param currentFileAction The {@link CurrentFilePreprocessAction} to run ///
+	/**
+	 * Runs the {@link CurrentFilePreprocessAction}
+	 * @param currentFileAction The {@link CurrentFilePreprocessAction} to run
+	 */
 	public static void runFileAction(CurrentFilePreprocessAction currentFileAction) throws IOException {
 		Path outFile = currentFileAction.outFile();
 		List<String> outLines = currentFileAction.outLines();

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -24,6 +24,8 @@ import java.util.Scanner;
 
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
 import com.minecrafttas.discombobulator.Discombobulator;
@@ -40,13 +42,16 @@ import com.minecrafttas.discombobulator.utils.SafeFileOperations;
  * 
  * @author Pancake, Scribble
  */
-public class TaskPreprocessWatch extends DefaultTask {
+public abstract class TaskPreprocessWatch extends DefaultTask {
 
 	private List<FileWatcherThread> threads = new ArrayList<>();
 
 	private CurrentFilePreprocessAction currentFileAction = null;
 
 	private boolean msgSeen = false;
+
+	@Input
+	abstract Property<String> getProjectName();
 
 	@TaskAction
 	public void preprocessWatch() throws Exception {
@@ -56,7 +61,7 @@ public class TaskPreprocessWatch extends DefaultTask {
 		lock.tryLock();
 
 		// Prepare list of physical version folders
-		Path baseProjectDir = this.getProject().getProjectDir().toPath();
+		Path baseProjectDir = Discombobulator.BASE_PROJECT_DIR;
 
 		LineFeedHelper.printMessage();
 
@@ -122,7 +127,7 @@ public class TaskPreprocessWatch extends DefaultTask {
 			e.printStackTrace();
 		}
 
-		if (version.equals(this.getProject().getName())) {
+		if (version.equals(getProjectName().get())) {
 			version = "Base";
 		}
 
@@ -259,25 +264,22 @@ public class TaskPreprocessWatch extends DefaultTask {
 		}
 	}
 
-	/// 
 	/// Stores data used for preprocessing the file that was edited most recently.
 	///
-	/// This fixes an issue where the IDE will behave weirdly, when trying to preprocess and replace a file,  
-	/// that is currently being worked on. So when saving a file,  
-	/// The file watcher would also replace the file that you just saved, leading to discrepancies and annoyances.
+	/// This fixes an issue where the IDE will behave weirdly, when trying to
+	/// preprocess and replace a file, that is currently being worked on. So when
+	/// saving a file, The file watcher would also replace the file that you just
+	/// saved, leading to discrepancies and annoyances.
 	///
 	/// With this, you can execute the preprocessing at a later time.
 	///
-	/// @author Scribble
-	///
+	/// @author Scribble ///
 	public static record CurrentFilePreprocessAction(List<String> outLines, Path inFile, Path outFile) {
 	}
 
-	///
 	/// Runs the {@link CurrentFilePreprocessAction}
 	///
-	/// @param currentFileAction The {@link CurrentFilePreprocessAction} to run
-	///
+	/// @param currentFileAction The {@link CurrentFilePreprocessAction} to run ///
 	public static void runFileAction(CurrentFilePreprocessAction currentFileAction) throws IOException {
 		Path outFile = currentFileAction.outFile();
 		List<String> outLines = currentFileAction.outLines();

--- a/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/LineFeedHelper.java
@@ -13,12 +13,12 @@ import com.minecrafttas.discombobulator.Discombobulator;
  */
 public class LineFeedHelper {
 
-	///
-	/// Prints information about the current line feed character to the console.
-	///
-	/// Including whether Disco is using the default line seperator or not
-	/// @throws Exception
-	///
+	/** 
+	 * Prints information about the current line feed character to the console.
+	 * Including whether Disco is using the default line seperator or not
+	 * 
+	 * @throws Exception
+	 */
 	public static void printMessage() throws Exception {
 		LineFeedHelper.checkLineFeed(Discombobulator.DEFAULT_LINE_FEED);
 		String property = System.getProperty("line.seperator");
@@ -32,11 +32,11 @@ public class LineFeedHelper {
 		}
 	}
 
-	///
-	/// Checks the line feed character
-	/// @param lineFeed The {@link Discombobulator#DEFAULT_LINE_FEED}
-	/// @throws Exception If the defaultLineFeed is not a line feed character
-	///
+	/**
+	 * Checks the line feed character
+	 * @param lineFeed The {@link Discombobulator#DEFAULT_LINE_FEED}
+	 * @throws Exception If the defaultLineFeed is not a line feed character
+	 */
 	public static void checkLineFeed(String lineFeed) throws Exception {
 		if (!isLineFeed(lineFeed)) {
 			throw new Exception("Property defaultLineFeed is neither \"\\r\\n\" nor \"\\n\"");


### PR DESCRIPTION
For once, gradle 9 actually does something useful.

Adding `org.gradle.configuration-cache=true` will instruct gradle to cache the config stage of any task. This is super helpful, as each new Minecraft version adds half a second each time you run a preprocessing command.

However this means I finally had to convert all `this.getProject()` into "task inputs"... Searching gradle docs is as always a pain, but this is worth the effort.

