### PR TITLE
Add unobfuscation support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.4
+version=1.5
 release=false
 org.gradle.configuration-cache=true

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -25,6 +25,8 @@ import com.minecrafttas.discombobulator.tasks.TaskPreprocessVersion;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessVersionError;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch;
 import com.minecrafttas.discombobulator.utils.Colors;
+import com.minecrafttas.discombobulator.utils.EmergencyTransformer;
+import com.minecrafttas.discombobulator.utils.Pair;
 import com.minecrafttas.discombobulator.utils.PathLock;
 
 /**
@@ -111,7 +113,7 @@ public class Discombobulator implements Plugin<Project> {
 		List<Task> compileTaskList = new ArrayList<>();
 		Map<String, Path> buildDirs = new HashMap<>();
 		for (Project subProject : project.getSubprojects()) {
-			Task compileTask = subProject.getTasksByName("remapJar", false).iterator().next();
+			Task compileTask = subProject.getTasksByName("build", false).iterator().next();
 			compileTaskList.add(compileTask);
 
 			buildDirs.put(subProject.getName(), getBuildDir(subProject).resolve("libs"));
@@ -172,7 +174,7 @@ public class Discombobulator implements Plugin<Project> {
 
 	public static String getSplash() {
 		return "\n" + (DISABLE_ANSI ? getColorLessSplash() : getColoredSplash()) + "\n\n"
-				+ getCenterText(String.format("Enable configuration cache today!")) + "\n"
+				+ getCenterText(String.format("Now with unobfuscated support!")) + "\n"
 				+ getCenterText("Created by Pancake and Scribble") + "\n"
 				+ getCenterText(discoVersion) + "\n\n";
 

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -25,8 +25,6 @@ import com.minecrafttas.discombobulator.tasks.TaskPreprocessVersion;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessVersionError;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch;
 import com.minecrafttas.discombobulator.utils.Colors;
-import com.minecrafttas.discombobulator.utils.EmergencyTransformer;
-import com.minecrafttas.discombobulator.utils.Pair;
 import com.minecrafttas.discombobulator.utils.PathLock;
 
 /**
@@ -81,6 +79,11 @@ public class Discombobulator implements Plugin<Project> {
 	 * used for the splash in the console
 	 */
 	private static String discoVersion;
+
+	/**
+	 * Versions where the accessor is changed to official mappings
+	 */
+	public static List<String> accessWidenerOfficialList = new ArrayList<>();
 
 	/**
 	 * Apply the gradle plugin to the project
@@ -155,15 +158,16 @@ public class Discombobulator implements Plugin<Project> {
 				return;
 			}
 			List<String> versionStrings = new ArrayList<>(versionPairs.keySet());
-			LinePreprocessor processor = new LinePreprocessor(versionStrings, config.getPatterns().get(), inverted);
+			LinePreprocessor lineProcessor = new LinePreprocessor(versionStrings, config.getPatterns().get(), inverted);
 
 			List<String> ignored = config.getIgnoredFileFormats().getOrElse(new ArrayList<>());
 			WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards(ignored).get();
 
-			Map<String, Map<String, Pair<String, String>>> emergencyTransformConfig = config.getEmergencyTransform().getOrNull();
-			EmergencyTransformer emergencyTransformer = new EmergencyTransformer(emergencyTransformConfig);
+//			Map<String, Map<String, Pair<String, String>>> emergencyTransformConfig = config.getEmergencyTransform().getOrNull();
+//			EmergencyTransformer emergencyTransformer = new EmergencyTransformer(emergencyTransformConfig, versionStrings);
+			accessWidenerOfficialList = config.getAccessWidenerOfficial().get();
 
-			fileProcessor = new FilePreprocessor(processor, fileFilter, emergencyTransformer);
+			fileProcessor = new FilePreprocessor(lineProcessor, fileFilter);
 
 			// Yes this is yoinked from the gradle forums to get the disco version. Is there
 			// a better method? Probably. Do I care? Currently, no.

--- a/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
+++ b/src/main/java/com/minecrafttas/discombobulator/Discombobulator.java
@@ -160,7 +160,10 @@ public class Discombobulator implements Plugin<Project> {
 			List<String> ignored = config.getIgnoredFileFormats().getOrElse(new ArrayList<>());
 			WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards(ignored).get();
 
-			fileProcessor = new FilePreprocessor(processor, fileFilter);
+			Map<String, Map<String, Pair<String, String>>> emergencyTransformConfig = config.getEmergencyTransform().getOrNull();
+			EmergencyTransformer emergencyTransformer = new EmergencyTransformer(emergencyTransformConfig);
+
+			fileProcessor = new FilePreprocessor(processor, fileFilter, emergencyTransformer);
 
 			// Yes this is yoinked from the gradle forums to get the disco version. Is there
 			// a better method? Probably. Do I care? Currently, no.

--- a/src/main/java/com/minecrafttas/discombobulator/config/PreprocessingConfiguration.java
+++ b/src/main/java/com/minecrafttas/discombobulator/config/PreprocessingConfiguration.java
@@ -6,7 +6,6 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 
-import com.minecrafttas.discombobulator.utils.Pair;
 import com.minecrafttas.discombobulator.utils.PortLock;
 
 /**
@@ -127,9 +126,15 @@ public abstract class PreprocessingConfiguration {
 	 */
 	public abstract Property<String> getDefaultLineFeed();
 
+//	/**
+//	 * <p>If a file needs transforming but does not support comments
+//	 * @return A map with the version number as key and a map as value which contains the filename and a pair of strings with search and replace respectively
+//	 */
+//	public abstract MapProperty<String, Map<String, Pair<String, String>>> getEmergencyTransform();
+
 	/**
-	 * <p>If a file needs transforming but does not support comments
-	 * @return A map with the version number as key and a map as value which contains the filename and a pair of strings with search and replace respectively
+	 * @return Versions where the accesswidener is changed to official mappings
 	 */
-	public abstract MapProperty<String, Map<String, Pair<String, String>>> getEmergencyTransform();
+	public abstract ListProperty<String> getAccessWidenerOfficial();
+
 }

--- a/src/main/java/com/minecrafttas/discombobulator/config/PreprocessingConfiguration.java
+++ b/src/main/java/com/minecrafttas/discombobulator/config/PreprocessingConfiguration.java
@@ -6,6 +6,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 
+import com.minecrafttas.discombobulator.utils.Pair;
 import com.minecrafttas.discombobulator.utils.PortLock;
 
 /**
@@ -125,4 +126,10 @@ public abstract class PreprocessingConfiguration {
 	 * @return The line feed string
 	 */
 	public abstract Property<String> getDefaultLineFeed();
+
+	/**
+	 * <p>If a file needs transforming but does not support comments
+	 * @return A map with the version number as key and a map as value which contains the filename and a pair of strings with search and replace respectively
+	 */
+	public abstract MapProperty<String, Map<String, Pair<String, String>>> getEmergencyTransform();
 }

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -41,11 +41,6 @@ public class FilePreprocessor {
 	 * Used for skipping certain files to be preprocessed, as e.g. binary files can't be preprocessed by the {@link LinePreprocessor}
 	 */
 	private final WildcardFileFilter fileFilter;
-	/**
-	 * The {@link EmergencyTransformer}.<br>
-	 * Used for search and replacing files that don't allow comments
-	 */
-	private final EmergencyTransformer emergencyTransformer;
 
 	/**
 	 * Creates a new {@link FilePreprocessor}
@@ -53,10 +48,9 @@ public class FilePreprocessor {
 	 * @param fileFilter The {@link #fileFilter}
 	 * @param emergencyTransformer The {@link EmergencyTransformer}
 	 */
-	public FilePreprocessor(LinePreprocessor processor, WildcardFileFilter fileFilter, EmergencyTransformer emergencyTransformer) {
+	public FilePreprocessor(LinePreprocessor processor, WildcardFileFilter fileFilter) {
 		this.lineProcessor = processor;
 		this.fileFilter = fileFilter;
-		this.emergencyTransformer = emergencyTransformer;
 	}
 
 	/**
@@ -187,6 +181,7 @@ public class FilePreprocessor {
 	 */
 	public List<String> preprocessLines(List<String> inLines, Path outFile, String version, String extension) throws Exception {
 		List<String> lines = lineProcessor.preprocess(version, inLines, extension);
+
 		writeLines(lines, outFile);
 		return lines;
 	}

--- a/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/FilePreprocessor.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.filefilter.WildcardFileFilter;
 import com.minecrafttas.discombobulator.Discombobulator;
 import com.minecrafttas.discombobulator.tasks.TaskPreprocessWatch.CurrentFilePreprocessAction;
 import com.minecrafttas.discombobulator.utils.BetterFileWalker;
+import com.minecrafttas.discombobulator.utils.EmergencyTransformer;
 import com.minecrafttas.discombobulator.utils.LineFeedHelper;
 import com.minecrafttas.discombobulator.utils.SafeFileOperations;
 
@@ -40,15 +41,22 @@ public class FilePreprocessor {
 	 * Used for skipping certain files to be preprocessed, as e.g. binary files can't be preprocessed by the {@link LinePreprocessor}
 	 */
 	private final WildcardFileFilter fileFilter;
+	/**
+	 * The {@link EmergencyTransformer}.<br>
+	 * Used for search and replacing files that don't allow comments
+	 */
+	private final EmergencyTransformer emergencyTransformer;
 
 	/**
 	 * Creates a new {@link FilePreprocessor}
 	 * @param processor The {@link #lineProcessor}
 	 * @param fileFilter The {@link #fileFilter}
+	 * @param emergencyTransformer The {@link EmergencyTransformer}
 	 */
-	public FilePreprocessor(LinePreprocessor processor, WildcardFileFilter fileFilter) {
+	public FilePreprocessor(LinePreprocessor processor, WildcardFileFilter fileFilter, EmergencyTransformer emergencyTransformer) {
 		this.lineProcessor = processor;
 		this.fileFilter = fileFilter;
+		this.emergencyTransformer = emergencyTransformer;
 	}
 
 	/**

--- a/src/main/java/com/minecrafttas/discombobulator/processor/LinePreprocessor.java
+++ b/src/main/java/com/minecrafttas/discombobulator/processor/LinePreprocessor.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.minecrafttas.discombobulator.Discombobulator;
 import com.minecrafttas.discombobulator.utils.Pair;
 
 /*
@@ -226,6 +227,9 @@ public class LinePreprocessor {
 
 			out.add(line);
 		}
+
+		//TODO Very dumb, very temporary method to fix accesswideners
+		out = makeAccessWidenerOfficial(fileending, targetVersion, out);
 
 		return out;
 	}
@@ -999,5 +1003,30 @@ public class LinePreprocessor {
 			}
 		}
 		return replacement;
+	}
+
+	/**
+	 * Very temporary method to support unobfuscated mcversions, by changing the "named" in the first line of the accesswidener to "official"
+	 * if a version is declared in the build.gradle
+	 * 
+	 * @param extension
+	 * @param targetVersion
+	 * @param lines
+	 * @return
+	 */
+	private List<String> makeAccessWidenerOfficial(String extension, String targetVersion, List<String> lines) {
+		if (!"accesswidener".equals(extension)) {
+			return lines;
+		}
+
+		if (Discombobulator.accessWidenerOfficialList.contains(targetVersion)) {
+			String line = lines.get(0).replace("named", "official");
+			lines.set(0, line);
+		} else {
+			String line = lines.get(0).replace("official", "named");
+			lines.set(0, line);
+		}
+
+		return lines;
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskCollectBuilds.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskCollectBuilds.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
@@ -19,6 +20,7 @@ import com.minecrafttas.discombobulator.Discombobulator;
  * 
  * @author Pancake
  */
+@CacheableTask
 public abstract class TaskCollectBuilds extends DefaultTask {
 
 	/**

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessBase.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessBase.java
@@ -8,6 +8,7 @@ import java.util.Map.Entry;
 
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.minecrafttas.discombobulator.Discombobulator;
@@ -30,6 +31,7 @@ import com.minecrafttas.discombobulator.utils.PortLock;
  * 
  * @author Pancake, Scribble
  */
+@CacheableTask
 public class TaskPreprocessBase extends DefaultTask {
 
 	@TaskAction

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersion.java
@@ -12,7 +12,10 @@ import java.util.Map.Entry;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import com.minecrafttas.discombobulator.Discombobulator;
@@ -35,8 +38,10 @@ import com.minecrafttas.discombobulator.utils.PortLock;
  * 
  * @author Scribble
  */
+@CacheableTask
 public abstract class TaskPreprocessVersion extends DefaultTask {
 
+	@PathSensitive(PathSensitivity.RELATIVE)
 	@InputDirectory
 	abstract DirectoryProperty getVersionDirectory();
 

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersionError.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessVersionError.java
@@ -1,6 +1,7 @@
 package com.minecrafttas.discombobulator.tasks;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
 
 /**
@@ -11,6 +12,7 @@ import org.gradle.api.tasks.TaskAction;
  * <p>But you can register separate tasks to the root project, that will execute before everything else, so to stop it,<br>
  * we just need to throw an exception and it will stop all following tasks. Thanks Gradle! 
  */
+@CacheableTask
 public class TaskPreprocessVersionError extends DefaultTask {
 
 	/**

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -154,7 +154,7 @@ public abstract class TaskPreprocessWatch extends DefaultTask {
 				// Get path relative to the root dir
 				String extension = FilenameUtils.getExtension(path.getFileName().toString());
 				try {
-					System.out.println(String.format("[%s%s%s]", PURPLE_BRIGHT, TaskPreprocessWatch.findVersionFromPath(path, versions), WHITE));
+					System.out.println(String.format("\n[%s%s%s]", PURPLE_BRIGHT, TaskPreprocessWatch.findVersionFromPath(path, versions), WHITE));
 					// Preprocess in all sub versions
 					currentFileAction = Discombobulator.fileProcessor.preprocessVersions(path, versions, extension, subSourceDir, true);
 

--- a/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
+++ b/src/main/java/com/minecrafttas/discombobulator/tasks/TaskPreprocessWatch.java
@@ -25,6 +25,7 @@ import java.util.Scanner;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
@@ -42,6 +43,7 @@ import com.minecrafttas.discombobulator.utils.SafeFileOperations;
  * 
  * @author Pancake, Scribble
  */
+@CacheableTask
 public abstract class TaskPreprocessWatch extends DefaultTask {
 
 	private List<FileWatcherThread> threads = new ArrayList<>();

--- a/src/main/java/com/minecrafttas/discombobulator/utils/EmergencyTransformer.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/EmergencyTransformer.java
@@ -1,7 +1,6 @@
 package com.minecrafttas.discombobulator.utils;
 
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -12,46 +11,38 @@ public class EmergencyTransformer {
 
 	private Map<String, Map<String, Pair<String, String>>> config;
 
-	public EmergencyTransformer(Map<String, Map<String, Pair<String, String>>> config) {
+	public EmergencyTransformer(Map<String, Map<String, Pair<String, String>>> config, List<String> versionStrings) {
 		this.config = config;
 	}
 
-	public List<String> transform(String targetVersion, Path file, List<String> lines) {
-		Map<String, Pair<String, String>> version = config.getOrDefault(targetVersion, new HashMap<>());
+	public List<String> transform(String sourceVersion, String targetVersion, Path file, List<String> lines) {
 
-		for (Entry<String, Pair<String, String>> filePatterns : version.entrySet()) {
-			String pattern = filePatterns.getKey();
-			Pair<String, String> searchReplace = filePatterns.getValue();
-			String search = searchReplace.left();
-			String replace = searchReplace.right();
-
-			replaceLines(file, lines, pattern, search, replace);
+		for (Entry<String, Map<String, Pair<String, String>>> filePattern : config.entrySet()) {
+			WildcardFileFilter filter = WildcardFileFilter.builder().setWildcards(filePattern.getKey()).get();
+			if (filter.matches(file)) {
+				Map<String, Pair<String, String>> versions = filePattern.getValue();
+				replaceVersion(targetVersion, lines, versions);
+			}
 		}
 
 		return lines;
 	}
 
-	public List<String> reverseTransform(String targetVersion, Path file, List<String> lines) {
-		Map<String, Pair<String, String>> version = config.getOrDefault(targetVersion, new HashMap<>());
-
-		for (Entry<String, Pair<String, String>> filePatterns : version.entrySet()) {
-			String pattern = filePatterns.getKey();
-			Pair<String, String> searchReplace = filePatterns.getValue();
-			String search = searchReplace.left();
-			String replace = searchReplace.right();
-
-			replaceLines(file, lines, pattern, replace, search);
+	private void replaceVersion(String targetVersion, List<String> lines, Map<String, Pair<String, String>> versions) {
+		for (Entry<String, Pair<String, String>> version : versions.entrySet()) {
+			if (targetVersion.equals(version.getKey())) {
+				replaceLines(lines, version);
+			}
 		}
-
-		return lines;
 	}
 
-	private void replaceLines(Path file, List<String> lines, String pattern, String search, String replace) {
-		WildcardFileFilter filter = WildcardFileFilter.builder().setWildcards(pattern).get();
-		if (filter.matches(file)) {
-			lines.forEach(line -> {
-				line = line.replace(search, replace);
-			});
-		}
+	private void replaceLines(List<String> lines, Entry<String, Pair<String, String>> version) {
+		Pair<String, String> searchReplace = version.getValue();
+		String search = searchReplace.left();
+		String replace = searchReplace.right();
+
+		lines.forEach(line -> {
+			line = line.replace(search, replace);
+		});
 	}
 }

--- a/src/main/java/com/minecrafttas/discombobulator/utils/EmergencyTransformer.java
+++ b/src/main/java/com/minecrafttas/discombobulator/utils/EmergencyTransformer.java
@@ -1,0 +1,57 @@
+package com.minecrafttas.discombobulator.utils;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+
+public class EmergencyTransformer {
+
+	private Map<String, Map<String, Pair<String, String>>> config;
+
+	public EmergencyTransformer(Map<String, Map<String, Pair<String, String>>> config) {
+		this.config = config;
+	}
+
+	public List<String> transform(String targetVersion, Path file, List<String> lines) {
+		Map<String, Pair<String, String>> version = config.getOrDefault(targetVersion, new HashMap<>());
+
+		for (Entry<String, Pair<String, String>> filePatterns : version.entrySet()) {
+			String pattern = filePatterns.getKey();
+			Pair<String, String> searchReplace = filePatterns.getValue();
+			String search = searchReplace.left();
+			String replace = searchReplace.right();
+
+			replaceLines(file, lines, pattern, search, replace);
+		}
+
+		return lines;
+	}
+
+	public List<String> reverseTransform(String targetVersion, Path file, List<String> lines) {
+		Map<String, Pair<String, String>> version = config.getOrDefault(targetVersion, new HashMap<>());
+
+		for (Entry<String, Pair<String, String>> filePatterns : version.entrySet()) {
+			String pattern = filePatterns.getKey();
+			Pair<String, String> searchReplace = filePatterns.getValue();
+			String search = searchReplace.left();
+			String replace = searchReplace.right();
+
+			replaceLines(file, lines, pattern, replace, search);
+		}
+
+		return lines;
+	}
+
+	private void replaceLines(Path file, List<String> lines, String pattern, String search, String replace) {
+		WildcardFileFilter filter = WildcardFileFilter.builder().setWildcards(pattern).get();
+		if (filter.matches(file)) {
+			lines.forEach(line -> {
+				line = line.replace(search, replace);
+			});
+		}
+	}
+}

--- a/src/test/java/com/minecrafttas/discombobulator/test/ProcessorTestAccessWidener.java
+++ b/src/test/java/com/minecrafttas/discombobulator/test/ProcessorTestAccessWidener.java
@@ -7,12 +7,13 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.minecrafttas.discombobulator.Discombobulator;
 import com.minecrafttas.discombobulator.processor.LinePreprocessor;
 import com.minecrafttas.discombobulator.utils.Pair;
 
 class ProcessorTestAccessWidener extends TestBase {
 
-	private List<String> allVersions = Arrays.asList("1.20.0", "1.19.3", "1.19.2", "1.19.0", "1.18.2", "1.18.1", "1.17.1", "1.16.5", "1.16.1", "infinity", "1.15.2", "1.14.4");
+	private List<String> allVersions = Arrays.asList("26.1", "1.20.0", "1.19.3", "1.19.2", "1.19.0", "1.18.2", "1.18.1", "1.17.1", "1.16.5", "1.16.1", "infinity", "1.15.2", "1.14.4");
 
 	private LinePreprocessor processor = new LinePreprocessor(allVersions, null);
 
@@ -72,6 +73,24 @@ class ProcessorTestAccessWidener extends TestBase {
 		String expectedName = "Expected1.14.4.txt";
 		String targetVersion = null;
 
+		Pair<List<String>, List<String>> lines = getLines(folder, actualName, expectedName);
+
+		List<String> linesActual = processor.preprocess(targetVersion, lines.left(), getExtension(actualName));
+
+		String actual = String.join("\n", linesActual);
+		String expected = String.join("\n", lines.right());
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testAccessWidenerChange() throws Exception {
+		String folder = "TestAccesswidener";
+		String actualName = "test.accesswidener";
+		String expectedName = "Expected26.1.txt";
+		String targetVersion = "26.1";
+
+		Discombobulator.accessWidenerOfficialList.add("26.1");
 		Pair<List<String>, List<String>> lines = getLines(folder, actualName, expectedName);
 
 		List<String> linesActual = processor.preprocess(targetVersion, lines.left(), getExtension(actualName));

--- a/src/test/resources/TestAccesswidener/Expected26.1.txt
+++ b/src/test/resources/TestAccesswidener/Expected26.1.txt
@@ -1,0 +1,11 @@
+accessWidener v1 official
+
+# Savestate Mod
+## 1.16.1
+Ac code for 1.16.1
+## 1.14.4
+#$$Ac code for 1.14.4
+## end
+
+# Dragon Manipulation
+accessible field net/minecraft/world/level/pathfinder/Path nodes Ljava/util/List;


### PR DESCRIPTION
Fabric decided to add a brand new gradle plugin which remobes the "remapJar" task and just calls it "jar". We can't have that, so I switched it out with "build" which should always be the same...

Furthermore, access wideners got changed, so you need to write "official" instead of "named". And of course, preprocessing doesn't work for this use case, because the statement *has to be* in the first line of the access widener...

I was first gonna add an "EmergencyTransformer" to allow for these kinds of shenanigans... But since I want to redo some logic for Disco 2 that adds multi modloader preprocessing, I thought I will do the quick and temporary setup by only preprocessing the .accesswidener files... I already do some exceptions for that with the comments...